### PR TITLE
Support filterFunction and spelFunction composition

### DIFF
--- a/applications/processor/filter-processor/README.adoc
+++ b/applications/processor/filter-processor/README.adoc
@@ -4,7 +4,7 @@
 Filter processor enables an application to examine the incoming payload and then applies a predicate against it which decides if the record needs to be continued.
 For example, if the incoming payload is of type `String` and you want to filter out anything that has less than five characters, you can run the filter processor as below.
 
-`java -jar filter-processor-kafka-<version>.jar --spel.function.expression=payload.length() > 4`
+`java -jar filter-processor-kafka-<version>.jar --filter.function.expression=payload.length() > 4`
 
 Change kafka to rabbit if you want to run it against RabbitMQ.
 
@@ -16,7 +16,7 @@ If the incoming type is `byte[]` and the content type is set to `text/plain` or 
 == Options
 
 //tag::configuration-properties[]
-$$spel.function.expression$$:: $$A SpEL expression to apply.$$ *($$String$$, default: `$$<none>$$`)*
+$$filter.function.expression$$:: $$A SpEL expression to apply.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 //end::ref-doc[]

--- a/applications/processor/filter-processor/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
+++ b/applications/processor/filter-processor/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
@@ -1,2 +1,2 @@
-configuration-properties.classes=org.springframework.cloud.fn.spel.SpelFunctionProperties
+configuration-properties.classes=org.springframework.cloud.fn.filter.FilterFunctionProperties
 

--- a/applications/source/time-source/src/test/java/org/springframework/cloud/stream/app/source/time/TimeSourceTests.java
+++ b/applications/source/time-source/src/test/java/org/springframework/cloud/stream/app/source/time/TimeSourceTests.java
@@ -71,14 +71,15 @@ public class TimeSourceTests {
 				TestChannelBinderConfiguration
 						.getCompleteConfiguration(TimeSourceTestApplication.class))
 								.web(WebApplicationType.NONE)
-								.run("--spring.cloud.stream.function.definition=timeSupplier|spelFunction|filterFunction",
-										"--spel.function.expression=payload.substring(payload.length() - 2)",
-										"--filter.function.expression=payload.endsWith(7)")) {
+								.run("--spring.cloud.function.definition=timeSupplier|headerEnricherFunction|filterFunction",
+										"--header.enricher.headers=seconds=T(java.lang.Integer).valueOf(payload.substring(payload.length() - 2))",
+										"--filter.function.expression=headers[seconds]%2==0")) {
 
 			OutputDestination target = context.getBean(OutputDestination.class);
 			Message<byte[]> sourceMessage = target.receive(10000);
 			final String actual = new String(sourceMessage.getPayload());
-			assertThat(actual).endsWith("7");
+			System.out.println(actual);
+			assertThat(((int) sourceMessage.getHeaders().get("seconds")) % 2).isZero();
 		}
 	}
 
@@ -89,7 +90,7 @@ public class TimeSourceTests {
 				TestChannelBinderConfiguration
 						.getCompleteConfiguration(TimeSourceTestApplication.class))
 								.web(WebApplicationType.NONE)
-								.run("--spring.cloud.stream.function.definition=timeSupplier|spelFunction|headerEnricherFunction|taskLaunchRequestFunction",
+								.run("--spring.cloud.function.definition=timeSupplier|spelFunction|headerEnricherFunction|taskLaunchRequestFunction",
 										"--spel.function.expression=payload.length()",
 										"--header.enricher.headers=task-id=payload*2",
 										"--spring.cloud.stream.bindings.output.destination=foo",

--- a/applications/source/time-source/src/test/java/org/springframework/cloud/stream/app/source/time/TimeSourceTests.java
+++ b/applications/source/time-source/src/test/java/org/springframework/cloud/stream/app/source/time/TimeSourceTests.java
@@ -66,18 +66,19 @@ public class TimeSourceTests {
 	}
 
 	@Test
-	public void testSourceComposedWithSpel() {
+	public void testSourceComposedWithSpelAndFilter() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				TestChannelBinderConfiguration
 						.getCompleteConfiguration(TimeSourceTestApplication.class))
 								.web(WebApplicationType.NONE)
-								.run("--spring.cloud.stream.function.definition=timeSupplier|spelFunction",
-										"--spel.function.expression=payload.length()")) {
+								.run("--spring.cloud.stream.function.definition=timeSupplier|spelFunction|filterFunction",
+										"--spel.function.expression=payload.substring(payload.length() - 2)",
+										"--filter.function.expression=payload.endsWith(7)")) {
 
 			OutputDestination target = context.getBean(OutputDestination.class);
 			Message<byte[]> sourceMessage = target.receive(10000);
 			final String actual = new String(sourceMessage.getPayload());
-			assertThat(Integer.valueOf(actual)).isEqualTo(17);
+			assertThat(actual).endsWith("7");
 		}
 	}
 

--- a/functions/function/filter-function/README.adoc
+++ b/functions/function/filter-function/README.adoc
@@ -14,11 +14,11 @@ Once injected, you can use the `apply` method of the `Function` to invoke it and
 
 ## Configuration Options
 
-The filter function makes uses of link:../spel-function/README.adoc[SpEL function].
+All configuration properties are prefixed with `filter.function`.
 
-For more information on the various options available, please see link:../spel-function/src/main/java/org/springframework/cloud/fn/spel/SpelFunctionProperties.java[SpelFunctionProperties.java]
+For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/filter/FilterFunctionProperties.java[FilterFunctionProperties.java]
 
-## Tests
+## Examples
 
 See this link:src/test/java/org/springframework/cloud/fn/filter/FilterFunctionApplicationTests.java[test suite] for examples of how this function is used.
 

--- a/functions/function/filter-function/pom.xml
+++ b/functions/function/filter-function/pom.xml
@@ -17,8 +17,12 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
-            <artifactId>spel-function</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <artifactId>payload-converter-function</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-integration</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionProperties.java
+++ b/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.filter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+/**
+ * Configuration properties for the SpEL function.
+ *
+ * @author Gary Russell
+ * @author Artem Bilan
+ */
+@ConfigurationProperties("filter.function")
+public class FilterFunctionProperties {
+
+	private static final Expression DEFAULT_EXPRESSION = new SpelExpressionParser().parseExpression("payload");
+
+	/**
+	 * A SpEL expression to apply.
+	 */
+	private String expression = DEFAULT_EXPRESSION.getExpressionString();
+
+	public String getExpression() {
+		return this.expression;
+	}
+
+	public void setExpression(String expression) {
+		this.expression = expression;
+	}
+
+}

--- a/functions/function/filter-function/src/test/java/org/springframework/cloud/fn/filter/FilterFunctionApplicationTests.java
+++ b/functions/function/filter-function/src/test/java/org/springframework/cloud/fn/filter/FilterFunctionApplicationTests.java
@@ -30,7 +30,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = "spel.function.expression=payload.length() > 5")
+@SpringBootTest(properties = "filter.function.expression=payload.length() > 5")
 @DirtiesContext
 public class FilterFunctionApplicationTests {
 


### PR DESCRIPTION
Refactor to support composition of filter and spel functions:

Provide `FilterFunctionProperties`  so `filter.function.expression`  and `spel.function.expression` can be specified. 

see `TimeSourceTests`