### PR TITLE
Fix file source

### DIFF
--- a/applications/source/file-source/pom.xml
+++ b/applications/source/file-source/pom.xml
@@ -58,6 +58,12 @@
                             <groupId>org.springframework.cloud.stream.app</groupId>
                             <artifactId>stream-applications-composite-function-support</artifactId>
                             <version>${stream-apps-core.version}</version>
+                            <exclusions>
+                                <exclusion>
+									<groupId>org.springframework.cloud.fn</groupId>
+                                    <artifactId>splitter-function</artifactId>
+                                </exclusion>
+                            </exclusions>
                         </dependency>
                     </dependencies>
                 </configuration>

--- a/applications/stream-applications-core/common/stream-applications-composite-function-support/src/main/java/org/springframework/cloud/stream/app/composite/function/common/FunctionBindingEnvironmentPostProcessor.java
+++ b/applications/stream-applications-core/common/stream-applications-composite-function-support/src/main/java/org/springframework/cloud/stream/app/composite/function/common/FunctionBindingEnvironmentPostProcessor.java
@@ -95,7 +95,7 @@ public class FunctionBindingEnvironmentPostProcessor implements EnvironmentPostP
 	}
 
 	private String functionDefinitionToChannelName(String functionDefinition) {
-		return functionDefinition.replaceAll("\\|", "");
+		return functionDefinition.replaceAll("\\||,", "");
 	}
 
 	private String functionDefinition(Environment environment) {

--- a/applications/stream-applications-core/common/stream-applications-composite-function-support/src/test/java/org/springframework/cloud/stream/app/composite/function/common/FunctionBindingsEnvironmentPostProcessorTests.java
+++ b/applications/stream-applications-core/common/stream-applications-composite-function-support/src/test/java/org/springframework/cloud/stream/app/composite/function/common/FunctionBindingsEnvironmentPostProcessorTests.java
@@ -37,6 +37,17 @@ public class FunctionBindingsEnvironmentPostProcessorTests {
 		assertThat(context.getEnvironment().getProperty("spring.cloud.stream.function.bindings.firstFunctionsecondFunction-in-0"))
 				.isEqualTo("input");
 	}
+	@Test
+	void destinationBindingsWithCommaDelimiter() {
+		ApplicationContext context = new SpringApplication(TestApp.class).run(
+				"--spring.cloud.stream.bindings.output.destination=foo",
+				"--spring.cloud.stream.bindings.input.destination=bar",
+				"--spring.cloud.function.definition=firstFunction,secondFunction");
+		assertThat(context.getEnvironment().getProperty("spring.cloud.stream.function.bindings.firstFunctionsecondFunction-out-0"))
+				.isEqualTo("output");
+		assertThat(context.getEnvironment().getProperty("spring.cloud.stream.function.bindings.firstFunctionsecondFunction-in-0"))
+				.isEqualTo("input");
+	}
 
 	@SpringBootApplication
 	static class TestApp {


### PR DESCRIPTION
Fixes #103 - excludes `splitter-function` from dependencies.  There may be some other sources that have the same issue. Also, includes changes to handle function composition with `,` or `|` delimiter