### PR TITLE
Add Aggregator function & processor

### DIFF
--- a/applications/processor/aggregator-processor/README.adoc
+++ b/applications/processor/aggregator-processor/README.adoc
@@ -1,0 +1,64 @@
+//tag::ref-doc[]
+= Aggregator Processor
+
+Aggregator processor enables an application to aggregates incoming messages into groups and release them into an output destination.
+
+`java -jar aggregator-processor-kafka-<version>.jar --aggregator.message-store-type=jdbc`
+
+Change kafka to rabbit if you want to run it against RabbitMQ.
+
+=== Payload
+
+== Options
+
+//tag::configuration-properties[]
+$$aggregator.aggregation$$:: $$SpEL expression for aggregation strategy. Default is collection of payloads$$ *($$Expression$$, default: `$$<none>$$`)*
+$$aggregator.correlation$$:: $$SpEL expression for correlation key. Default to correlationId header$$ *($$Expression$$, default: `$$<none>$$`)*
+$$aggregator.group-timeout$$:: $$SpEL expression for timeout to expiring uncompleted groups$$ *($$Expression$$, default: `$$<none>$$`)*
+$$aggregator.message-store-entity$$:: $$Persistence message store entity: table prefix in RDBMS, collection name in MongoDb, etc$$ *($$String$$, default: `$$<none>$$`)*
+$$aggregator.message-store-type$$:: $$Message store type$$ *($$String$$, default: `$$<none>$$`)*
+$$aggregator.release$$:: $$SpEL expression for release strategy. Default is based on the sequenceSize header$$ *($$Expression$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.authentication-database$$:: $$Authentication database name.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.auto-index-creation$$:: $$Whether to enable auto-index creation.$$ *($$Boolean$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.database$$:: $$Database name.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.field-naming-strategy$$:: $$Fully qualified name of the FieldNamingStrategy to use.$$ *($$Class<?>$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.grid-fs-database$$:: $$GridFS database name.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.host$$:: $$Mongo server host. Cannot be set with URI.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.password$$:: $$Login password of the mongo server. Cannot be set with URI.$$ *($$Character[]$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.port$$:: $$Mongo server port. Cannot be set with URI.$$ *($$Integer$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.replica-set-name$$:: $$Required replica set name for the cluster. Cannot be set with URI.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.uri$$:: $$Mongo database URI. Cannot be set with host, port, credentials and replica set name.$$ *($$String$$, default: `$$mongodb://localhost/test$$`)*
+$$spring.data.mongodb.username$$:: $$Login user of the mongo server. Cannot be set with URI.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.data.mongodb.uuid-representation$$:: $$Representation to use when converting a UUID to a BSON binary value.$$ *($$UuidRepresentation$$, default: `$$java-legacy$$`, possible values: `UNSPECIFIED`,`STANDARD`,`C_SHARP_LEGACY`,`JAVA_LEGACY`,`PYTHON_LEGACY`)*
+$$spring.datasource.continue-on-error$$:: $$Whether to stop if an error occurs while initializing the database.$$ *($$Boolean$$, default: `$$false$$`)*
+$$spring.datasource.data$$:: $$Data (DML) script resource references.$$ *($$List<String>$$, default: `$$<none>$$`)*
+$$spring.datasource.data-password$$:: $$Password of the database to execute DML scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.data-username$$:: $$Username of the database to execute DML scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.driver-class-name$$:: $$Fully qualified name of the JDBC driver. Auto-detected based on the URL by default.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.generate-unique-name$$:: $$Whether to generate a random datasource name.$$ *($$Boolean$$, default: `$$true$$`)*
+$$spring.datasource.initialization-mode$$:: $$Initialize the datasource with available DDL and DML scripts.$$ *($$DataSourceInitializationMode$$, default: `$$embedded$$`, possible values: `ALWAYS`,`EMBEDDED`,`NEVER`)*
+$$spring.datasource.jndi-name$$:: $$JNDI location of the datasource. Class, url, username and password are ignored when set.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.name$$:: $$Name of the datasource. Default to "testdb" when using an embedded database.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.password$$:: $$Login password of the database.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.platform$$:: $$Platform to use in the DDL or DML scripts (such as schema-${platform}.sql or data-${platform}.sql).$$ *($$String$$, default: `$$all$$`)*
+$$spring.datasource.schema$$:: $$Schema (DDL) script resource references.$$ *($$List<String>$$, default: `$$<none>$$`)*
+$$spring.datasource.schema-password$$:: $$Password of the database to execute DDL scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.schema-username$$:: $$Username of the database to execute DDL scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.separator$$:: $$Statement separator in SQL initialization scripts.$$ *($$String$$, default: `$$;$$`)*
+$$spring.datasource.sql-script-encoding$$:: $$SQL scripts encoding.$$ *($$Charset$$, default: `$$<none>$$`)*
+$$spring.datasource.type$$:: $$Fully qualified name of the connection pool implementation to use. By default, it is auto-detected from the classpath.$$ *($$Class<DataSource>$$, default: `$$<none>$$`)*
+$$spring.datasource.url$$:: $$JDBC URL of the database.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.datasource.username$$:: $$Login username of the database.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.mongodb.embedded.features$$:: $$Comma-separated list of features to enable. Uses the defaults of the configured version by default.$$ *($$Set<Feature>$$, default: `$$[sync_delay]$$`)*
+$$spring.mongodb.embedded.version$$:: $$Version of Mongo to use.$$ *($$String$$, default: `$$3.5.5$$`)*
+$$spring.redis.client-name$$:: $$Client name to be set on connections with CLIENT SETNAME.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.redis.database$$:: $$Database index used by the connection factory.$$ *($$Integer$$, default: `$$0$$`)*
+$$spring.redis.host$$:: $$Redis server host.$$ *($$String$$, default: `$$localhost$$`)*
+$$spring.redis.password$$:: $$Login password of the redis server.$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.redis.port$$:: $$Redis server port.$$ *($$Integer$$, default: `$$6379$$`)*
+$$spring.redis.ssl$$:: $$Whether to enable SSL support.$$ *($$Boolean$$, default: `$$false$$`)*
+$$spring.redis.timeout$$:: $$Connection timeout.$$ *($$Duration$$, default: `$$<none>$$`)*
+$$spring.redis.url$$:: $$Connection URL. Overrides host, port, and password. User is ignored. Example: redis://user:password@example.com:6379$$ *($$String$$, default: `$$<none>$$`)*
+//end::configuration-properties[]
+
+//end::ref-doc[]

--- a/applications/processor/aggregator-processor/pom.xml
+++ b/applications/processor/aggregator-processor/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>aggregator-processor</artifactId>
+    <name>aggregator-processor</name>
+    <description>aggregator processor apps</description>
+    <version>3.0.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>org.springframework.cloud.stream.app</groupId>
+        <artifactId>stream-applications-core</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>aggregator-function</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-app-starter-doc-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.cloud.stream.app.plugin</groupId>
+                <artifactId>spring-cloud-stream-app-maven-plugin</artifactId>
+                <configuration>
+                    <generatedApp>
+                        <name>aggregator</name>
+                        <type>processor</type>
+                        <version>${project.version}</version>
+                        <configClass>org.springframework.cloud.fn.aggregator.AggregatorFunctionConfiguration.class</configClass>
+                        <functionDefinition>aggregatorFunction</functionDefinition>
+                    </generatedApp>
+
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.springframework.cloud.fn</groupId>
+                            <artifactId>aggregator-function</artifactId>
+                        </dependency>
+                    </dependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/libs-milestone-local</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>spring-releases</id>
+            <name>Spring Releases</name>
+            <url>https://repo.spring.io/release</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>spring-libs-release</id>
+            <name>Spring Libs Release</name>
+            <url>https://repo.spring.io/libs-release</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>spring-milestone-release</id>
+            <name>Spring Milestone Release</name>
+            <url>https://repo.spring.io/libs-milestone</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-releases</id>
+            <name>Spring Releases</name>
+            <url>https://repo.spring.io/libs-release</url>
+        </pluginRepository>
+        <pluginRepository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
+        </pluginRepository>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/libs-milestone-local</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
+++ b/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
@@ -1,0 +1,8 @@
+configuration-properties.classes=org.springframework.cloud.fn.aggregator.AggregatorFunctionProperties,\
+  org.springframework.boot.autoconfigure.mongo.MongoProperties,\
+  org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoProperties,\
+  org.springframework.boot.autoconfigure.data.redis.RedisProperties,\
+  org.springframework.boot.autoconfigure.jdbc.DataSourceProperties,\
+  org.springframework.geode.boot.autoconfigure.configuration.GemFireProperties
+
+

--- a/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata.properties
+++ b/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata.properties
@@ -1,0 +1,7 @@
+configuration-properties.classes=org.springframework.cloud.fn.aggregator.AggregatorFunctionProperties,\
+  org.springframework.boot.autoconfigure.mongo.MongoProperties,\
+  org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoProperties,\
+  org.springframework.boot.autoconfigure.data.redis.RedisProperties,\
+  org.springframework.boot.autoconfigure.jdbc.DataSourceProperties,\
+  org.springframework.geode.boot.autoconfigure.configuration.GemFireProperties
+

--- a/applications/processor/aggregator-processor/src/test/java/org/springframework/cloud/fn/aggregator/AggregatorProcessorTests.java
+++ b/applications/processor/aggregator-processor/src/test/java/org/springframework/cloud/fn/aggregator/AggregatorProcessorTests.java
@@ -1,0 +1,58 @@
+package org.springframework.cloud.fn.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+
+public class AggregatorProcessorTests {
+
+	@Test
+	public void testFilterProcessor() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+				TestChannelBinderConfiguration.getCompleteConfiguration(AggregatorProcessorTestApplication.class))
+				.web(WebApplicationType.NONE)
+				.run("--spring.cloud.function.definition=aggregatorFunction",
+						"--aggregator.message-store-type=jdbc")) {
+
+			InputDestination processorInput = context.getBean(InputDestination.class);
+			OutputDestination processorOutput = context.getBean(OutputDestination.class);
+
+			processorInput.send(
+					MessageBuilder.withPayload("2")
+							.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+							.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 2)
+							.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+							.build());
+			processorInput.send(
+					MessageBuilder.withPayload("1")
+							.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+							.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 1)
+							.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+							.build());
+
+			Message<byte[]> receive = processorOutput.receive(10_000);
+
+			assertThat(receive).isNotNull()
+					.extracting(Message::getPayload)
+					.extracting(String::new)
+					.isEqualTo("[\"2\",\"1\"]");
+		}
+	}
+
+	@SpringBootApplication
+	public static class AggregatorProcessorTestApplication {
+
+	}
+
+}

--- a/applications/processor/pom.xml
+++ b/applications/processor/pom.xml
@@ -10,6 +10,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>aggregator-processor</module>
         <module>bridge-processor</module>
         <module>filter-processor</module>
         <module>groovy-processor</module>

--- a/functions/function-dependencies/pom.xml
+++ b/functions/function-dependencies/pom.xml
@@ -187,6 +187,11 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
+                <artifactId>aggregator-function</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>filter-function</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/functions/function/aggregator-function/README.adoc
+++ b/functions/function/aggregator-function/README.adoc
@@ -1,0 +1,25 @@
+# Aggregator Function
+
+This module provides an aggregation function that can be reused and composed in other applications.
+
+## Beans for injection
+
+You can import the `AggregatorFunctionConfiguration` in a Spring Boot application and then inject the following bean.
+
+`aggregatorFunction`
+
+You can use `aggregatorFunction` as a qualifier when injecting.
+
+Once injected, you can use the `apply` method of the `Function` to invoke it and get the result.
+
+## Configuration Options
+
+For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionProperties.java[AggregatorFunctionProperties.java]
+
+## Tests
+
+See this link:src/test/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionApplicationTests.java[test suite] for examples of how this function is used.
+
+## Other usage
+
+See this link:../../../applications/processor/aggregator-processor/README.adoc[README] where this function is used to create a Spring Cloud Stream application.

--- a/functions/function/aggregator-function/pom.xml
+++ b/functions/function/aggregator-function/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>aggregator-function</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>aggregator-function</name>
+    <description>Spring Native Function for Aggregator</description>
+
+    <parent>
+        <groupId>org.springframework.cloud.fn</groupId>
+        <artifactId>spring-functions-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../spring-functions-parent</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>config-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-integration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!--MongoDb-->
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--Redis-->
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!--Gemfire-->
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-gemfire</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.geode</groupId>
+            <artifactId>spring-geode-starter</artifactId>
+            <version>1.3.2.RELEASE</version>
+        </dependency>
+
+        <!--JDBC-->
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionConfiguration.java
+++ b/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionConfiguration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.function.Function;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.aggregator.CorrelationStrategy;
+import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
+import org.springframework.integration.aggregator.ExpressionEvaluatingCorrelationStrategy;
+import org.springframework.integration.aggregator.ExpressionEvaluatingMessageGroupProcessor;
+import org.springframework.integration.aggregator.ExpressionEvaluatingReleaseStrategy;
+import org.springframework.integration.aggregator.MessageGroupProcessor;
+import org.springframework.integration.aggregator.ReleaseStrategy;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.FluxMessageChannel;
+import org.springframework.integration.config.AggregatorFactoryBean;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * @author Artem Bilan
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AggregatorFunctionProperties.class)
+public class AggregatorFunctionConfiguration {
+
+	@Autowired
+	private AggregatorFunctionProperties properties;
+
+	@Autowired
+	private BeanFactory beanFactory;
+
+	@Bean
+	public Function<Flux<Message<?>>, Flux<Message<?>>> aggregatorFunction(FluxMessageChannel inputChannel,
+			FluxMessageChannel outputChannel) {
+
+		return input -> Flux.from(outputChannel)
+				.doOnSubscribe((sub) -> inputChannel.subscribeTo(input));
+	}
+
+	@Bean
+	public FluxMessageChannel inputChannel() {
+		return new FluxMessageChannel();
+	}
+
+	@Bean
+	public FluxMessageChannel outputChannel() {
+		return new FluxMessageChannel();
+	}
+
+	@Bean
+	@ServiceActivator(inputChannel = "inputChannel")
+	public AggregatorFactoryBean aggregator(
+			ObjectProvider<CorrelationStrategy> correlationStrategy,
+			ObjectProvider<ReleaseStrategy> releaseStrategy,
+			ObjectProvider<MessageGroupProcessor> messageGroupProcessor,
+			ObjectProvider<MessageGroupStore> messageStore,
+			@Qualifier("outputChannel") MessageChannel outputChannel) {
+
+		AggregatorFactoryBean aggregator = new AggregatorFactoryBean();
+		aggregator.setExpireGroupsUponCompletion(true);
+		aggregator.setSendPartialResultOnExpiry(true);
+		aggregator.setGroupTimeoutExpression(this.properties.getGroupTimeout());
+
+		aggregator.setCorrelationStrategy(correlationStrategy.getIfAvailable());
+		aggregator.setReleaseStrategy(releaseStrategy.getIfAvailable());
+
+		MessageGroupProcessor groupProcessor = messageGroupProcessor.getIfAvailable();
+
+		if (groupProcessor == null) {
+			groupProcessor = new DefaultAggregatingMessageGroupProcessor();
+			((BeanFactoryAware) groupProcessor).setBeanFactory(this.beanFactory);
+		}
+		aggregator.setProcessorBean(groupProcessor);
+
+		aggregator.setMessageStore(messageStore.getIfAvailable());
+		aggregator.setOutputChannel(outputChannel);
+
+		return aggregator;
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = AggregatorFunctionProperties.PREFIX, name = "correlation")
+	@ConditionalOnMissingBean
+	public CorrelationStrategy correlationStrategy() {
+		return new ExpressionEvaluatingCorrelationStrategy(this.properties.getCorrelation());
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = AggregatorFunctionProperties.PREFIX, name = "release")
+	@ConditionalOnMissingBean
+	public ReleaseStrategy releaseStrategy() {
+		return new ExpressionEvaluatingReleaseStrategy(this.properties.getRelease());
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = AggregatorFunctionProperties.PREFIX, name = "aggregation")
+	@ConditionalOnMissingBean
+	public MessageGroupProcessor messageGroupProcessor() {
+		return new ExpressionEvaluatingMessageGroupProcessor(this.properties.getAggregation().getExpressionString());
+	}
+
+
+	@Configuration
+	@ConditionalOnMissingBean(MessageGroupStore.class)
+	@Import({ MessageStoreConfiguration.Mongo.class, MessageStoreConfiguration.Redis.class,
+			MessageStoreConfiguration.Gemfire.class, MessageStoreConfiguration.Jdbc.class })
+	protected static class MessageStoreAutoConfiguration {
+
+	}
+
+}

--- a/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionProperties.java
+++ b/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionProperties.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.expression.Expression;
+
+/**
+ * Configuration properties for the Aggregator function.
+ *
+ * @author Artem Bilan
+ */
+@ConfigurationProperties("aggregator")
+public class AggregatorFunctionProperties {
+
+	static final String PREFIX = "aggregator";
+
+	/**
+	 * SpEL expression for correlation key. Default to correlationId header.
+	 */
+	private Expression correlation;
+
+	/**
+	 * SpEL expression for release strategy. Default is based on the sequenceSize header.
+	 */
+	private Expression release;
+
+	/**
+	 * SpEL expression for aggregation strategy. Default is collection of payloads.
+	 */
+	private Expression aggregation;
+
+	/**
+	 * SpEL expression for timeout to expiring uncompleted groups.
+	 */
+	private Expression groupTimeout;
+
+	/**
+	 * Message store type.
+	 */
+	private String messageStoreType = MessageStoreType.SIMPLE;
+
+	/**
+	 * Persistence message store entity: table prefix in RDBMS, collection name in MongoDb, etc.
+	 */
+	private String messageStoreEntity;
+
+	public Expression getCorrelation() {
+		return this.correlation;
+	}
+
+	public void setCorrelation(Expression correlation) {
+		this.correlation = correlation;
+	}
+
+	public Expression getRelease() {
+		return this.release;
+	}
+
+	public void setRelease(Expression release) {
+		this.release = release;
+	}
+
+	public Expression getAggregation() {
+		return this.aggregation;
+	}
+
+	public void setAggregation(Expression aggregation) {
+		this.aggregation = aggregation;
+	}
+
+	public Expression getGroupTimeout() {
+		return this.groupTimeout;
+	}
+
+	public void setGroupTimeout(Expression groupTimeout) {
+		this.groupTimeout = groupTimeout;
+	}
+
+	public String getMessageStoreEntity() {
+		return this.messageStoreEntity;
+	}
+
+	public void setMessageStoreEntity(String messageStoreEntity) {
+		this.messageStoreEntity = messageStoreEntity;
+	}
+
+	public String getMessageStoreType() {
+		return this.messageStoreType;
+	}
+
+	public void setMessageStoreType(String messageStoreType) {
+		this.messageStoreType = messageStoreType;
+	}
+
+	static final class MessageStoreType {
+
+		static final String SIMPLE = "simple";
+
+		static final String JDBC = "jdbc";
+
+		static final String MONGODB = "mongodb";
+
+		static final String REDIS = "redis";
+
+		static final String GEMFIRE = "gemfire";
+
+	}
+
+}

--- a/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
+++ b/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.Properties;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.geode.boot.autoconfigure.ClientCacheAutoConfiguration;
+
+/**
+ * An {@link EnvironmentPostProcessor} to add {@code spring.autoconfigure.exclude} property
+ * since we can't use {@code application.properties} from the library perspective.
+ *
+ * @author Artem Bilan
+ */
+public class ExcludeStoresAutoConfigurationEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		MutablePropertySources propertySources = environment.getPropertySources();
+		Properties properties = new Properties();
+
+		properties.setProperty("spring.autoconfigure.exclude",
+				DataSourceAutoConfiguration.class.getName() + ", " +
+						DataSourceTransactionManagerAutoConfiguration.class.getName() + ", " +
+						MongoAutoConfiguration.class.getName() + ", " +
+						MongoDataAutoConfiguration.class.getName() + ", " +
+						MongoRepositoriesAutoConfiguration.class.getName() + ", " +
+						EmbeddedMongoAutoConfiguration.class.getName() + ", " +
+						ClientCacheAutoConfiguration.class.getName() + ", " +
+						RedisAutoConfiguration.class.getName() + ", " +
+						RedisRepositoriesAutoConfiguration.class.getName());
+
+		propertySources.addLast(
+				new PropertiesPropertySource("aggregator.exclude.stores.auto-configuration", properties));
+	}
+
+}

--- a/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/MessageStoreConfiguration.java
+++ b/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/MessageStoreConfiguration.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.Arrays;
+
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.cache.Region;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.gemfire.client.ClientRegionFactoryBean;
+import org.springframework.data.gemfire.config.annotation.EnablePdx;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.geode.boot.autoconfigure.ClientCacheAutoConfiguration;
+import org.springframework.integration.gemfire.store.GemfireMessageStore;
+import org.springframework.integration.jdbc.store.JdbcMessageStore;
+import org.springframework.integration.mongodb.store.ConfigurableMongoDbMessageStore;
+import org.springframework.integration.mongodb.support.BinaryToMessageConverter;
+import org.springframework.integration.mongodb.support.MessageToBinaryConverter;
+import org.springframework.integration.redis.store.RedisMessageStore;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.util.StringUtils;
+
+
+/**
+ * A helper class containing configuration classes for particular technologies
+ * to expose an appropriate {@link org.springframework.integration.store.MessageStore} bean
+ * via matched configuration properties.
+ *
+ * @author Artem Bilan
+ */
+class MessageStoreConfiguration {
+
+	@ConditionalOnClass(ConfigurableMongoDbMessageStore.class)
+	@ConditionalOnProperty(prefix = AggregatorFunctionProperties.PREFIX,
+			name = "message-store-type",
+			havingValue = AggregatorFunctionProperties.MessageStoreType.MONGODB)
+	@Import({ MongoAutoConfiguration.class,
+			MongoDataAutoConfiguration.class,
+			EmbeddedMongoAutoConfiguration.class })
+	static class Mongo {
+
+		@Bean
+		public MessageGroupStore messageStore(MongoTemplate mongoTemplate, AggregatorFunctionProperties properties) {
+			if (StringUtils.hasText(properties.getMessageStoreEntity())) {
+				return new ConfigurableMongoDbMessageStore(mongoTemplate, properties.getMessageStoreEntity());
+			}
+			else {
+				return new ConfigurableMongoDbMessageStore(mongoTemplate);
+			}
+		}
+
+		@Bean
+		@Primary
+		public MongoCustomConversions mongoDbCustomConversions() {
+			return new MongoCustomConversions(Arrays.asList(
+					new MessageToBinaryConverter(), new BinaryToMessageConverter()));
+		}
+
+	}
+
+	@ConditionalOnClass(RedisMessageStore.class)
+	@ConditionalOnProperty(prefix = AggregatorFunctionProperties.PREFIX,
+			name = "message-store-type",
+			havingValue = AggregatorFunctionProperties.MessageStoreType.REDIS)
+	@Import(RedisAutoConfiguration.class)
+	static class Redis {
+
+		@Bean
+		public MessageGroupStore messageStore(RedisTemplate<?, ?> redisTemplate) {
+			return new RedisMessageStore(redisTemplate.getConnectionFactory());
+		}
+
+	}
+
+	@ConditionalOnClass(GemfireMessageStore.class)
+	@ConditionalOnProperty(prefix = AggregatorFunctionProperties.PREFIX,
+			name = "message-store-type",
+			havingValue = AggregatorFunctionProperties.MessageStoreType.GEMFIRE)
+	@Import(ClientCacheAutoConfiguration.class)
+	@EnablePdx
+	static class Gemfire {
+
+		@Bean
+		@ConditionalOnMissingBean
+		public ClientRegionFactoryBean<?, ?> gemfireRegion(GemFireCache cache, AggregatorFunctionProperties properties) {
+			ClientRegionFactoryBean<?, ?> clientRegionFactoryBean = new ClientRegionFactoryBean<>();
+			clientRegionFactoryBean.setCache(cache);
+			clientRegionFactoryBean.setName(properties.getMessageStoreEntity());
+			return clientRegionFactoryBean;
+		}
+
+		@Bean
+		public MessageGroupStore messageStore(Region<Object, Object> region) {
+			return new GemfireMessageStore(region);
+		}
+
+	}
+
+	@ConditionalOnClass(JdbcMessageStore.class)
+	@ConditionalOnProperty(prefix = AggregatorFunctionProperties.PREFIX,
+			name = "message-store-type",
+			havingValue = AggregatorFunctionProperties.MessageStoreType.JDBC)
+	@Import({
+			DataSourceAutoConfiguration.class,
+			DataSourceTransactionManagerAutoConfiguration.class })
+	static class Jdbc {
+
+		@Bean
+		public MessageGroupStore messageStore(JdbcTemplate jdbcTemplate, AggregatorFunctionProperties properties) {
+			JdbcMessageStore messageStore = new JdbcMessageStore(jdbcTemplate);
+			if (StringUtils.hasText(properties.getMessageStoreEntity())) {
+				messageStore.setTablePrefix(properties.getMessageStoreEntity());
+			}
+			return messageStore;
+		}
+
+	}
+
+}

--- a/functions/function/aggregator-function/src/main/resources/META-INF/spring.factories
+++ b/functions/function/aggregator-function/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  org.springframework.cloud.fn.aggregator.AggregatorFunctionConfiguration
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.springframework.cloud.fn.aggregator.ExcludeStoresAutoConfigurationEnvironmentPostProcessor

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/AbstractAggregatorFunctionTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/AbstractAggregatorFunctionTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.function.Function;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * @author Artem Bilan
+ */
+@SpringBootTest
+@DirtiesContext
+public abstract class AbstractAggregatorFunctionTests {
+
+	@Autowired
+	protected Function<Flux<Message<?>>, Flux<Message<?>>> aggregatorFunction;
+
+	@Autowired(required = false)
+	protected MessageGroupStore messageGroupStore;
+
+	@Autowired
+	protected AggregatingMessageHandler aggregatingMessageHandler;
+
+	@SpringBootApplication
+	static class AggregatorFunctionTestApplication {
+
+	}
+
+}

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.integration.mongodb.store.ConfigurableMongoDbMessageStore;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ */
+@TestPropertySource(properties = {
+		"aggregator.correlation=T(Thread).currentThread().id",
+		"aggregator.release=!messages.?[payload == 'bar'].empty",
+		"aggregator.aggregation=#this.?[payload == 'foo'].![payload]",
+		"aggregator.messageStoreType=mongodb",
+		"aggregator.message-store-entity=aggregatorTest" })
+@AutoConfigureDataMongo
+public class CustomPropsAndMongoMessageStoreAggregatorTests extends AbstractAggregatorFunctionTests {
+
+	@Test
+	public void test() {
+		Flux<Message<?>> input =
+				Flux.just("foo", "bar")
+						.map(GenericMessage::new);
+
+		Flux<Message<?>> output = this.aggregatorFunction.apply(input);
+
+		output.as(StepVerifier::create)
+				.assertNext((message) ->
+						assertThat(message)
+								.extracting(Message::getPayload)
+								.isInstanceOf(List.class)
+								.asList()
+								.hasSize(1)
+								.element(0).isEqualTo("foo"))
+				.thenCancel()
+				.verify();
+
+		assertThat(this.messageGroupStore).isInstanceOf(ConfigurableMongoDbMessageStore.class);
+		assertThat(TestUtils.getPropertyValue(this.messageGroupStore, "collectionName")).isEqualTo("aggregatorTest");
+		assertThat(this.aggregatingMessageHandler.getMessageStore()).isSameAs(this.messageGroupStore);
+	}
+
+}

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.store.SimpleMessageStore;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ */
+public class DefaultAggregatorTests extends AbstractAggregatorFunctionTests {
+
+	@Test
+	public void test() {
+		Flux<Message<?>> input =
+				Flux.just(MessageBuilder.withPayload("2")
+								.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 2)
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+								.build(),
+						MessageBuilder.withPayload("1")
+								.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 1)
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+								.build());
+
+		Flux<Message<?>> output = this.aggregatorFunction.apply(input);
+
+		output.as(StepVerifier::create)
+				.assertNext((message) ->
+						assertThat(message)
+								.extracting(Message::getPayload)
+								.isInstanceOf(List.class)
+								.asList()
+								.hasSize(2)
+								.contains("1", "2"))
+				.thenCancel()
+				.verify();
+
+		assertThat(this.messageGroupStore).isNull();
+		assertThat(this.aggregatingMessageHandler.getMessageStore()).isInstanceOf(SimpleMessageStore.class);
+	}
+
+}

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/GroupTimeOutAndGemfireMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/GroupTimeOutAndGemfireMessageStoreAggregatorTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.gemfire.store.GemfireMessageStore;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ */
+@TestPropertySource(properties = {
+		"aggregator.message-store-type=gemfire",
+		"aggregator.groupTimeout=10" })
+public class GroupTimeOutAndGemfireMessageStoreAggregatorTests extends AbstractAggregatorFunctionTests {
+
+	@Test
+	public void test() {
+		Flux<Message<?>> input =
+				Flux.just(MessageBuilder.withPayload("1")
+						.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+						.build());
+
+		Flux<Message<?>> output = this.aggregatorFunction.apply(input);
+
+		output.as(StepVerifier::create)
+				.assertNext((message) ->
+						assertThat(message)
+								.extracting(Message::getPayload)
+								.isInstanceOf(List.class)
+								.asList()
+								.hasSize(1)
+								.contains("1"))
+				.thenCancel()
+				.verify();
+
+		assertThat(this.messageGroupStore).isInstanceOf(GemfireMessageStore.class);
+		assertThat(this.aggregatingMessageHandler.getMessageStore()).isSameAs(this.messageGroupStore);
+	}
+
+}

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.jdbc.store.JdbcMessageStore;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ */
+@TestPropertySource(properties = "aggregator.message-store-type=jdbc")
+public class JdbcMessageStoreAggregatorTests extends AbstractAggregatorFunctionTests {
+
+	@Test
+	public void test() {
+		Flux<Message<?>> input =
+				Flux.just(MessageBuilder.withPayload("2")
+								.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 2)
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+								.build(),
+						MessageBuilder.withPayload("1")
+								.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 1)
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+								.build());
+
+		Flux<Message<?>> output = this.aggregatorFunction.apply(input);
+
+		output.as(StepVerifier::create)
+				.assertNext((message) ->
+						assertThat(message)
+								.extracting(Message::getPayload)
+								.isInstanceOf(List.class)
+								.asList()
+								.hasSize(2)
+								.contains("1", "2"))
+				.thenCancel()
+				.verify();
+
+		assertThat(this.messageGroupStore).isInstanceOf(JdbcMessageStore.class);
+
+		assertThat(this.aggregatingMessageHandler.getMessageStore()).isSameAs(this.messageGroupStore);
+	}
+
+}

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/RedisMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/RedisMessageStoreAggregatorTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.fn.aggregator;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.redis.store.RedisMessageStore;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ */
+@TestPropertySource(properties = "aggregator.message-store-type=redis")
+@Disabled("Needs real Redis Server to be run")
+public class RedisMessageStoreAggregatorTests extends AbstractAggregatorFunctionTests {
+
+	@Test
+	public void test() {
+		Flux<Message<?>> input =
+				Flux.just(MessageBuilder.withPayload("2")
+								.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 2)
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+								.build(),
+						MessageBuilder.withPayload("1")
+								.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "my_correlation")
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 1)
+								.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 2)
+								.build());
+
+		Flux<Message<?>> output = this.aggregatorFunction.apply(input);
+
+		output.as(StepVerifier::create)
+				.assertNext((message) ->
+						assertThat(message)
+								.extracting(Message::getPayload)
+								.isInstanceOf(List.class)
+								.asList()
+								.hasSize(2)
+								.contains("1", "2"))
+				.thenCancel()
+				.verify();
+
+		assertThat(this.messageGroupStore).isInstanceOf(RedisMessageStore.class);
+
+		assertThat(this.aggregatingMessageHandler.getMessageStore()).isSameAs(this.messageGroupStore);
+	}
+
+}

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -72,6 +72,7 @@
 		<module>consumer/twitter-consumer</module>
 		<module>consumer/wavefront-consumer</module>
 
+		<module>function/aggregator-function</module>
 		<module>function/filter-function</module>
 		<module>function/header-enricher-function</module>
 		<module>function/http-request-function</module>


### PR DESCRIPTION
* Have all the required dependencies in class path which give us a `MessageGroupStore` implementation
* Disable all their auto-configurations in the `ExcludeStoresAutoConfigurationEnvironmentPostProcessor`
* Enable only those which are configured by the `aggregator.messageStoreType` property
* Implement a fully reactive function around an aggregator making an interaction via a pair of `FluxMessageChannel`