### PR TITLE
GH-110: Fix filter function for emitting `null`

### DIFF
--- a/applications/processor/filter-processor/README.adoc
+++ b/applications/processor/filter-processor/README.adoc
@@ -16,7 +16,7 @@ If the incoming type is `byte[]` and the content type is set to `text/plain` or 
 == Options
 
 //tag::configuration-properties[]
-$$filter.function.expression$$:: $$A SpEL expression to apply.$$ *($$String$$, default: `$$<none>$$`)*
+$$filter.function.expression$$:: $$Boolean SpEL expression to apply against request message to filter.$$ *($$String$$, default: `$$true$$`)*
 //end::configuration-properties[]
 
 //end::ref-doc[]

--- a/applications/processor/filter-processor/pom.xml
+++ b/applications/processor/filter-processor/pom.xml
@@ -20,23 +20,6 @@
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>filter-function</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-json</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/functions/function/filter-function/pom.xml
+++ b/functions/function/filter-function/pom.xml
@@ -17,12 +17,21 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>config-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>payload-converter-function</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -39,6 +48,11 @@
                     <artifactId>junit-vintage-engine</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionConfiguration.java
+++ b/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionConfiguration.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.Flux;
  * @author Artem Bilan
  * @author David Turanski
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(FilterFunctionProperties.class)
 public class FilterFunctionConfiguration {
 

--- a/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionConfiguration.java
+++ b/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionConfiguration.java
@@ -16,15 +16,15 @@
 
 package org.springframework.cloud.fn.filter;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.transformer.ExpressionEvaluatingTransformer;
 import org.springframework.messaging.Message;
+
+import reactor.core.publisher.Flux;
 
 /**
  * @author Artem Bilan
@@ -35,20 +35,19 @@ import org.springframework.messaging.Message;
 public class FilterFunctionConfiguration {
 
 	@Bean
-	public Function<Message<?>, Message<?>> filterFunction(
+	public Function<Flux<Message<?>>, Flux<Message<?>>> filterFunction(
 			ExpressionEvaluatingTransformer filterExpressionEvaluatingTransformer) {
 
-		return message -> Optional.of(message)
-				.filter(m -> (Boolean) filterExpressionEvaluatingTransformer.transform(m).getPayload())
-				.orElse(null);
+		return flux ->
+				flux.filter((message) ->
+						(Boolean) filterExpressionEvaluatingTransformer.transform(message).getPayload());
 	}
 
 	@Bean
 	public ExpressionEvaluatingTransformer filterExpressionEvaluatingTransformer(
 			FilterFunctionProperties filterFunctionProperties) {
 
-		return new ExpressionEvaluatingTransformer(new SpelExpressionParser()
-				.parseExpression(filterFunctionProperties.getExpression()));
+		return new ExpressionEvaluatingTransformer(filterFunctionProperties.getExpression());
 	}
 
 }

--- a/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionProperties.java
+++ b/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionProperties.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.fn.filter;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.expression.Expression;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.expression.ValueExpression;
 
 /**
  * Configuration properties for the SpEL function.
@@ -29,12 +29,10 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 @ConfigurationProperties("filter.function")
 public class FilterFunctionProperties {
 
-	private static final Expression DEFAULT_EXPRESSION = new SpelExpressionParser().parseExpression("payload");
-
 	/**
-	 * A SpEL expression to apply.
+	 * Boolean SpEL expression to apply against request message to filter.
 	 */
-	private Expression expression = DEFAULT_EXPRESSION;
+	private Expression expression = new ValueExpression<>(true);
 
 	public Expression getExpression() {
 		return this.expression;

--- a/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionProperties.java
+++ b/functions/function/filter-function/src/main/java/org/springframework/cloud/fn/filter/FilterFunctionProperties.java
@@ -34,13 +34,13 @@ public class FilterFunctionProperties {
 	/**
 	 * A SpEL expression to apply.
 	 */
-	private String expression = DEFAULT_EXPRESSION.getExpressionString();
+	private Expression expression = DEFAULT_EXPRESSION;
 
-	public String getExpression() {
+	public Expression getExpression() {
 		return this.expression;
 	}
 
-	public void setExpression(String expression) {
+	public void setExpression(Expression expression) {
 		this.expression = expression;
 	}
 

--- a/functions/function/filter-function/src/main/resources/application.properties
+++ b/functions/function/filter-function/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spel.function.expression=true


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/110

Turns out when functions are composed in the Spring Cloud Stream environment,
they are called via reactive wrappers which don't allow to emit `null` from the
`map()` operator.

* Make `filterFunction` fully reactive to reply on the `Flux.filter()` operator
* Add `config-common` for auto-conversion string configuration options into `Expression` instances
* Add `spring-boot-starter-json` dependency since it is required by the `SpelExpressionConverterConfiguration`
* Add `reactor-test` dependency to test the final solution
* Remove redundant dependencies from the `filter-processor`