### PR TITLE
refactor versions from pom files

### DIFF
--- a/functions/common/aws-s3-common/pom.xml
+++ b/functions/common/aws-s3-common/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>aws-s3-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>aws-s3-common</name>
-    <description>aws-s3 consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>aws-s3-common</artifactId>
+    <name>aws-s3-common</name>
+    <description>aws-s3 consumer</description>
 
     <properties>
         <spring-integration-aws.version>2.3.3.RELEASE</spring-integration-aws.version>

--- a/functions/common/cdc-debezium-boot-starter/pom.xml
+++ b/functions/common/cdc-debezium-boot-starter/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>cdc-debezium-boot-starter</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>cdc-debezium-boot-starter</name>
-	<description>Change Data Capture (CDC) Debezium Boot Starter</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-common-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>cdc-debezium-boot-starter</artifactId>
+	<name>cdc-debezium-boot-starter</name>
+	<description>Change Data Capture (CDC) Debezium Boot Starter</description>
 
 	<properties>
 		<version.debezium>1.2.1.Final</version.debezium>
@@ -30,17 +29,6 @@
 					<groupId>org.slf4j</groupId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 
 		<!-- -->
@@ -118,58 +106,58 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>io.fabric8</groupId>
-				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.33.0</version>
-				<configuration>
-					<images>
-						<image>
-							<alias>mysql</alias>
-							<name>debezium/example-mysql:1.0</name>
-							<run>
-								<env>
-									<MYSQL_ROOT_PASSWORD>debezium</MYSQL_ROOT_PASSWORD>
-									<MYSQL_USER>mysqluser</MYSQL_USER>
-									<MYSQL_PASSWORD>mysqlpw</MYSQL_PASSWORD>
-								</env>
-								<ports>
-									<port>3306:3306</port>
-								</ports>
-								<wait>
-									<log>port: 3306</log>
-									<time>30000</time>
-								</wait>
-							</run>
-						</image>
-					</images>
-				</configuration>
-				<executions>
-					<execution>
-						<id>start</id>
-						<!--<phase>pre-integration-test</phase>-->
-						<phase>generate-test-resources</phase>
-						<goals>
-							<goal>build</goal>
-							<goal>start</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>stop</id>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>stop-pre</id>
-						<phase>clean</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+<!--			<plugin>-->
+<!--				<groupId>io.fabric8</groupId>-->
+<!--				<artifactId>docker-maven-plugin</artifactId>-->
+<!--				<version>0.33.0</version>-->
+<!--				<configuration>-->
+<!--					<images>-->
+<!--						<image>-->
+<!--							<alias>mysql</alias>-->
+<!--							<name>debezium/example-mysql:1.0</name>-->
+<!--							<run>-->
+<!--								<env>-->
+<!--									<MYSQL_ROOT_PASSWORD>debezium</MYSQL_ROOT_PASSWORD>-->
+<!--									<MYSQL_USER>mysqluser</MYSQL_USER>-->
+<!--									<MYSQL_PASSWORD>mysqlpw</MYSQL_PASSWORD>-->
+<!--								</env>-->
+<!--								<ports>-->
+<!--									<port>3306:3306</port>-->
+<!--								</ports>-->
+<!--								<wait>-->
+<!--									<log>port: 3306</log>-->
+<!--									<time>30000</time>-->
+<!--								</wait>-->
+<!--							</run>-->
+<!--						</image>-->
+<!--					</images>-->
+<!--				</configuration>-->
+<!--				<executions>-->
+<!--					<execution>-->
+<!--						<id>start</id>-->
+<!--						&lt;!&ndash;<phase>pre-integration-test</phase>&ndash;&gt;-->
+<!--						<phase>generate-test-resources</phase>-->
+<!--						<goals>-->
+<!--							<goal>build</goal>-->
+<!--							<goal>start</goal>-->
+<!--						</goals>-->
+<!--					</execution>-->
+<!--					<execution>-->
+<!--						<id>stop</id>-->
+<!--						<phase>post-integration-test</phase>-->
+<!--						<goals>-->
+<!--							<goal>stop</goal>-->
+<!--						</goals>-->
+<!--					</execution>-->
+<!--					<execution>-->
+<!--						<id>stop-pre</id>-->
+<!--						<phase>clean</phase>-->
+<!--						<goals>-->
+<!--							<goal>stop</goal>-->
+<!--						</goals>-->
+<!--					</execution>-->
+<!--				</executions>-->
+<!--			</plugin>-->
 		</plugins>
 	</build>
 </project>

--- a/functions/common/cdc-debezium-common/pom.xml
+++ b/functions/common/cdc-debezium-common/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>cdc-debezium-common</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>cdc-debezium-common</name>
-	<description>Change Data Capture (CDC) Debezium Common</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-common-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>cdc-debezium-common</artifactId>
+	<name>cdc-debezium-common</name>
+	<description>Change Data Capture (CDC) Debezium Common</description>
 
 	<properties>
 		<version.debezium>1.2.1.Final</version.debezium>
@@ -98,7 +97,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>config-common</artifactId>
-			<version>${spring-cloud-fn.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>

--- a/functions/common/config-common/pom.xml
+++ b/functions/common/config-common/pom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>config-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>config-common</name>
-    <description>Function Common Configuration Components</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>config-common</artifactId>
+    <name>config-common</name>
+    <description>Function Common Configuration Components</description>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/functions/common/file-common/pom.xml
+++ b/functions/common/file-common/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>file-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>file-common</name>
-    <description>file common</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>file-common</artifactId>
+    <name>file-common</name>
+    <description>file common</description>
 
     <dependencies>
         <dependency>

--- a/functions/common/ftp-common/pom.xml
+++ b/functions/common/ftp-common/pom.xml
@@ -1,41 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>ftp-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>ftp-common</name>
-    <description>ftp common</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>ftp-common</artifactId>
+    <name>ftp-common</name>
+    <description>ftp common</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-ftp</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/common/function-test-support/pom.xml
+++ b/functions/common/function-test-support/pom.xml
@@ -1,72 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>function-test-support</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>function-test-support</name>
-    <description>file consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>function-test-support</artifactId>
+    <name>function-test-support</name>
+    <description>file consumer</description>
 
     <properties>
         <sshd-core.version>1.6.0</sshd-core.version>
-        <test-containers.version> 1.14.2</test-containers.version>
         <apache-ftpserver.version>1.1.1</apache-ftpserver.version>
         <geode-starter.version>1.2.7.RELEASE</geode-starter.version>
         <awaitility.version>4.0.3</awaitility.version>
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-geode</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-ftp</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-websocket</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftpserver-core</artifactId>
             <version>${apache-ftpserver.version}</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-ftp</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>compile</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
             <version>${sshd-core.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${test-containers.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-geode</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-websocket</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/common/geode-common/pom.xml
+++ b/functions/common/geode-common/pom.xml
@@ -1,27 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>geode-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>geode-common</name>
-    <description>Geode Common Components</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>geode-common</artifactId>
+    <name>geode-common</name>
+    <description>Geode Common Components</description>
+
     <properties>
 <!--        <geode-starter.version>1.2.7.RELEASE</geode-starter.version>-->
         <org-json.version>20200518</org-json.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
@@ -31,11 +28,7 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-geode</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/common/metadata-store-common/pom.xml
+++ b/functions/common/metadata-store-common/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>metadata-store-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>metadata-store-common</name>
-    <description>metadata-store common</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>metadata-store-common</artifactId>
+    <name>metadata-store-common</name>
+    <description>metadata-store common</description>
 
     <properties>
         <aws-java-sdk.version>1.11.439</aws-java-sdk.version>
@@ -21,27 +20,6 @@
     </properties>
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!--Redis-->
         <dependency>
@@ -158,11 +136,7 @@
             <version>${aws-java-sdk.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/common/mqtt-common/pom.xml
+++ b/functions/common/mqtt-common/pom.xml
@@ -1,36 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>mqtt-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>mqtt-common</name>
-    <description>file consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>mqtt-common</artifactId>
+    <name>mqtt-common</name>
+    <description>file consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-mqtt</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/common/pom.xml
+++ b/functions/common/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.cloud.fn</groupId>
+		<artifactId>java-functions-parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>java-functions-common-parent</artifactId>
+	<name>java-functions-common-parent</name>
+	<description>Pivotal Java Functions Common Parent</description>
+	<packaging>pom</packaging>
+
+  	<modules>
+
+		<module>aws-s3-common</module>
+		<module>config-common</module>
+		<module>file-common</module>
+		<module>ftp-common</module>
+		<module>function-test-support</module>
+		<module>geode-common</module>
+		<module>metadata-store-common</module>
+		<module>mqtt-common</module>
+		<module>tcp-common</module>
+		<module>twitter-common</module>
+		<module>tensorflow-common</module>
+		<module>cdc-debezium-common</module>
+		<module>cdc-debezium-boot-starter</module>
+
+	</modules>
+
+</project>

--- a/functions/common/tcp-common/pom.xml
+++ b/functions/common/tcp-common/pom.xml
@@ -1,37 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>tcp-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>tcp-common</name>
-    <description>tcp common</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>tcp-common</artifactId>
+    <name>tcp-common</name>
+    <description>tcp common</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-ip</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/common/tensorflow-common/README.adoc
+++ b/functions/common/tensorflow-common/README.adoc
@@ -11,7 +11,7 @@ Quick Start: just add the following dependency:
     <dependency>
         <groupId>org.springframework.cloud.fn</groupId>
         <artifactId>tensorflow-common</artifactId>
-        <version>${spring-cloud-fn.version}</version>
+        <version>${revision}</version>
     </dependency>
 ----
 

--- a/functions/common/tensorflow-common/pom.xml
+++ b/functions/common/tensorflow-common/pom.xml
@@ -2,20 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
-	<artifactId>tensorflow-common</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>tensorflow-common</name>
-	<description>tensorflow common</description>
+	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-common-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
 
-	<modelVersion>4.0.0</modelVersion>
+	<artifactId>tensorflow-common</artifactId>
+	<name>tensorflow-common</name>
+	<description>tensorflow common</description>
 
 	<properties>
 		<checkstyle.skip>true</checkstyle.skip>

--- a/functions/common/twitter-common/pom.xml
+++ b/functions/common/twitter-common/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>twitter-common</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>twitter-common</name>
-    <description>Twitter common</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-common-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>twitter-common</artifactId>
+    <name>twitter-common</name>
+    <description>Twitter common</description>
 
     <properties>
         <twitter4j.version>4.0.7</twitter4j.version>
@@ -25,34 +24,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-ip</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>config-common</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/functions/consumer/analytics-consumer/pom.xml
+++ b/functions/consumer/analytics-consumer/pom.xml
@@ -3,17 +3,16 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>analytics-consumer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>analytics-consumer</name>
-	<description>Spring Native Consumer for computing meters</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-consumer-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>analytics-consumer</artifactId>
+	<name>analytics-consumer</name>
+	<description>Spring Native Consumer for computing meters</description>
 
 	<dependencies>
 		<dependency>
@@ -24,7 +23,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>config-common</artifactId>
-			<version>${spring-cloud-fn.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/functions/consumer/cassandra-consumer/pom.xml
+++ b/functions/consumer/cassandra-consumer/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>cassandra-consumer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>cassandra-consumer</name>
-	<description>Cassandra Consumer</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-consumer-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>cassandra-consumer</artifactId>
+	<name>cassandra-consumer</name>
+	<description>Cassandra Consumer</description>
 
 	<properties>
 		<springIntegrationCassandara.version>0.8.0.RELEASE</springIntegrationCassandara.version>

--- a/functions/consumer/elasticsearch-consumer/pom.xml
+++ b/functions/consumer/elasticsearch-consumer/pom.xml
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>elasticsearch-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>elasticsearch-consumer</name>
-    <description>elasticsearch consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
-    <properties>
-        <test-containers.version>1.14.3</test-containers.version>
-    </properties>
+    <artifactId>elasticsearch-consumer</artifactId>
+    <name>elasticsearch-consumer</name>
+    <description>elasticsearch consumer</description>
 
     <dependencies>
         <dependency>
@@ -43,12 +38,12 @@
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>config-common</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>payload-converter-function</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/functions/consumer/file-consumer/pom.xml
+++ b/functions/consumer/file-consumer/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>file-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>file-consumer</name>
-    <description>file consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>file-consumer</artifactId>
+    <name>file-consumer</name>
+    <description>file consumer</description>
 
     <dependencies>
         <dependency>

--- a/functions/consumer/ftp-consumer/pom.xml
+++ b/functions/consumer/ftp-consumer/pom.xml
@@ -1,45 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>ftp-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>ftp-consumer</name>
-    <description>file consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>ftp-consumer</artifactId>
+    <name>ftp-consumer</name>
+    <description>file consumer</description>
+
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.cloud.fn</groupId>
-            <artifactId>ftp-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-ftp</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
+            <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>ftp-common</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>

--- a/functions/consumer/geode-consumer/pom.xml
+++ b/functions/consumer/geode-consumer/pom.xml
@@ -2,62 +2,39 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>geode-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>geode-consumer</name>
-    <description>Geode consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>geode-consumer</artifactId>
+    <name>geode-consumer</name>
+    <description>Geode consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-gemfire</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>geode-common</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>config-common</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>function-test-support</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -65,6 +42,7 @@
             <artifactId>lombok</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/consumer/jdbc-consumer/pom.xml
+++ b/functions/consumer/jdbc-consumer/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>jdbc-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>jdbc-consumer</name>
-    <description>jdbc consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>jdbc-consumer</artifactId>
+    <name>jdbc-consumer</name>
+    <description>jdbc consumer</description>
 
     <dependencies>
         <dependency>

--- a/functions/consumer/log-consumer/pom.xml
+++ b/functions/consumer/log-consumer/pom.xml
@@ -2,23 +2,22 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>log-consumer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>log-consumer</name>
-	<description>Log Consumer</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-consumer-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>log-consumer</artifactId>
+	<name>log-consumer</name>
+	<description>Log Consumer</description>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>payload-converter-function</artifactId>
-			<version>${project.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>

--- a/functions/consumer/mongodb-consumer/pom.xml
+++ b/functions/consumer/mongodb-consumer/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>mongodb-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>mongodb-consumer</name>
-    <description>Mongo DB consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>mongodb-consumer</artifactId>
+    <name>mongodb-consumer</name>
+    <description>Mongo DB consumer</description>
 
     <dependencies>
         <dependency>

--- a/functions/consumer/mqtt-consumer/pom.xml
+++ b/functions/consumer/mqtt-consumer/pom.xml
@@ -1,52 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>mqtt-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>mqtt-consumer</name>
-    <description>mqtt consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>mqtt-consumer</artifactId>
+    <name>mqtt-consumer</name>
+    <description>mqtt consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>mqtt-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.9.1</version>
+            <version>${test-containers.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 </project>

--- a/functions/consumer/pom.xml
+++ b/functions/consumer/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.cloud.fn</groupId>
+		<artifactId>java-functions-parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>java-functions-consumer-parent</artifactId>
+	<name>java-functions-consumer-parent</name>
+	<description>Pivotal Java Functions Consumer Parent</description>
+	<packaging>pom</packaging>
+
+  	<modules>
+
+		<module>cassandra-consumer</module>
+		<module>elasticsearch-consumer</module>
+		<module>analytics-consumer</module>
+		<module>file-consumer</module>
+		<module>ftp-consumer</module>
+		<module>geode-consumer</module>
+		<module>jdbc-consumer</module>
+		<module>log-consumer</module>
+		<module>mongodb-consumer</module>
+		<module>mqtt-consumer</module>
+		<module>rabbit-consumer</module>
+		<module>redis-consumer</module>
+		<module>sftp-consumer</module>
+		<module>tcp-consumer</module>
+		<module>websocket-consumer</module>
+		<module>s3-consumer</module>
+		<module>twitter-consumer</module>
+		<module>wavefront-consumer</module>
+		<module>rsocket-consumer</module>
+
+	</modules>
+
+</project>

--- a/functions/consumer/rabbit-consumer/pom.xml
+++ b/functions/consumer/rabbit-consumer/pom.xml
@@ -1,40 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>rabbit-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>rabbit-consumer</name>
-    <description>Rabbit consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>rabbit-consumer</artifactId>
+    <name>rabbit-consumer</name>
+    <description>Rabbit consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-amqp</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/consumer/redis-consumer/pom.xml
+++ b/functions/consumer/redis-consumer/pom.xml
@@ -2,84 +2,48 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>redis-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>redis-consumer</name>
-    <description>Redis Consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>redis-consumer</artifactId>
+    <name>redis-consumer</name>
+    <description>Redis Consumer</description>
 
     <properties>
         <spring-cloud-starters.version>2.2.0.RELEASE</spring-cloud-starters.version>
-        <embedded-redis.version>1.48</embedded-redis.version>
+        <embedded-redis.version>1.83</embedded-redis.version>
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-redis</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.playtika.testcontainers</groupId>
             <artifactId>embedded-redis</artifactId>
             <version>${embedded-redis.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter</artifactId>
             <version>${spring-cloud-starters.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test-support</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/consumer/rsocket-consumer/pom.xml
+++ b/functions/consumer/rsocket-consumer/pom.xml
@@ -3,36 +3,21 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>rsocket-consumer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>rsocket-consumer</name>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-consumer-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
 
+	<artifactId>rsocket-consumer</artifactId>
+	<name>rsocket-consumer</name>
+
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-rsocket</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/functions/consumer/s3-consumer/pom.xml
+++ b/functions/consumer/s3-consumer/pom.xml
@@ -1,57 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>s3-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>s3-consumer</name>
-    <description>s3 consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>s3-consumer</artifactId>
+    <name>s3-consumer</name>
+    <description>s3 consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>aws-s3-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>file-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>config-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
+
 </project>

--- a/functions/consumer/sftp-consumer/pom.xml
+++ b/functions/consumer/sftp-consumer/pom.xml
@@ -1,46 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>sftp-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>sftp-consumer</name>
-    <description>file consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>sftp-consumer</artifactId>
+    <name>sftp-consumer</name>
+    <description>file consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-sftp</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>function-test-support</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/consumer/tcp-consumer/pom.xml
+++ b/functions/consumer/tcp-consumer/pom.xml
@@ -1,52 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>tcp-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>tcp-consumer</name>
-    <description>tcp consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>tcp-consumer</artifactId>
+    <name>tcp-consumer</name>
+    <description>tcp consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>tcp-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/consumer/twitter-consumer/pom.xml
+++ b/functions/consumer/twitter-consumer/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>twitter-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>twitter-consumer</name>
-    <description>twitter consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>twitter-consumer</artifactId>
+    <name>twitter-consumer</name>
+    <description>twitter consumer</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>twitter-common</artifactId>
@@ -24,34 +24,7 @@
             <artifactId>payload-converter-function</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/consumer/wavefront-consumer/pom.xml
+++ b/functions/consumer/wavefront-consumer/pom.xml
@@ -2,64 +2,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>wavefront-consumer</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>wavefront-consumer</name>
-	<description>Wavefront Consumer</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-consumer-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>wavefront-consumer</artifactId>
+	<name>wavefront-consumer</name>
+	<description>Wavefront Consumer</description>
 
 	<properties>
 		<json-path.version>2.4.0</json-path.version>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>provided</scope>
-		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-integration</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>config-common</artifactId>
-			<version>${spring-cloud-fn.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.8.2</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 </project>

--- a/functions/consumer/websocket-consumer/pom.xml
+++ b/functions/consumer/websocket-consumer/pom.xml
@@ -1,60 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>websocket-consumer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>websocket-consumer</name>
-    <description>websocket consumer</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-consumer-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>websocket-consumer</artifactId>
+    <name>websocket-consumer</name>
+    <description>websocket consumer</description>
+
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-messaging</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-websocket</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>function-test-support</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/function-dependencies/pom.xml
+++ b/functions/function-dependencies/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>java-functions-parent</artifactId>
-        <groupId>org.springframework.cloud.fn</groupId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.cloud.fn</groupId>
+        <artifactId>java-functions-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
 
     <artifactId>function-dependencies</artifactId>
     <packaging>pom</packaging>
@@ -18,257 +18,257 @@
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>mail-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>syslog-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>cdc-debezium-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>file-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>ftp-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>geode-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>http-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>jdbc-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>jms-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>mongodb-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>mqtt-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>rabbit-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>s3-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>sftp-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>tcp-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>time-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>twitter-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>websocket-supplier</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>analytics-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>elasticsearch-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>rsocket-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>cassandra-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>file-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>ftp-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>geode-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>jdbc-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>log-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>mongodb-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>mqtt-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>rabbit-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>redis-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>s3-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>sftp-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>tcp-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>twitter-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>wavefront-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>websocket-consumer</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>aggregator-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>filter-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>header-enricher-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>http-request-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>image-recognition-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>object-detection-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>payload-converter-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>semantic-segmentation-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>spel-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>splitter-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>task-launch-request-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>tasklauncher-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>twitter-function</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud.fn</groupId>
                 <artifactId>function-test-support</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/functions/function/aggregator-function/pom.xml
+++ b/functions/function/aggregator-function/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>aggregator-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>aggregator-function</name>
-    <description>Spring Native Function for Aggregator</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-function-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>aggregator-function</artifactId>
+    <name>aggregator-function</name>
+    <description>Spring Native Function for Aggregator</description>
 
     <dependencies>
         <dependency>

--- a/functions/function/filter-function/pom.xml
+++ b/functions/function/filter-function/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>filter-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>filter-function</name>
-    <description>Spring Native Function for applying filter SpEL expressions</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-function-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>filter-function</artifactId>
+    <name>filter-function</name>
+    <description>Spring Native Function for applying filter SpEL expressions</description>
 
     <dependencies>
         <dependency>

--- a/functions/function/header-enricher-function/pom.xml
+++ b/functions/function/header-enricher-function/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>header-enricher-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>header-enricher-function</name>
-    <description>Spring Native Function for applying message header enrichment</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-function-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>header-enricher-function</artifactId>
+    <name>header-enricher-function</name>
+    <description>Spring Native Function for applying message header enrichment</description>
 
     <dependencies>
         <dependency>

--- a/functions/function/http-request-function/pom.xml
+++ b/functions/function/http-request-function/pom.xml
@@ -2,65 +2,45 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>http-request-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>http-request-function</name>
-    <description>Spring Native Function for Submitting an HTTP request</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-function-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>http-request-function</artifactId>
+    <name>http-request-function</name>
+    <description>Spring Native Function for Submitting an HTTP request</description>
 
     <properties>
         <mockwebserver.version>4.6.0</mockwebserver.version>
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>config-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-messaging</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
         </dependency>
+
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/function/image-recognition-function/README.adoc
+++ b/functions/function/image-recognition-function/README.adoc
@@ -25,7 +25,7 @@ Add the `image-recognition` dependency to the pom (use the latest version availa
 <dependency>
     <groupId>org.springframework.cloud.fn</groupId>
     <artifactId>image-recognition-function</artifactId>
-    <version>${spring-cloud-fn.version}</version>
+    <version>${revision}</version>
 </dependency>
 ----
 

--- a/functions/function/image-recognition-function/pom.xml
+++ b/functions/function/image-recognition-function/pom.xml
@@ -2,31 +2,33 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>image-recognition-function</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>image-recognition-function</name>
-	<description>Spring Native Function for Tensorflow Integration</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-function-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>image-recognition-function</artifactId>
+	<name>image-recognition-function</name>
+	<description>Spring Native Function for Tensorflow Integration</description>
 
 	<properties>
 		<commons-io.version>1.3.2</commons-io.version>
 	</properties>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>tensorflow-common</artifactId>
-			<version>${spring-cloud-fn.version}</version>
+			<version>${project.version}</version>
 		</dependency>
+
 	</dependencies>
 
 	<repositories>
+
 		<repository>
 			<id>tensorflow-snapshots</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,5 +36,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
+
 	</repositories>
+
 </project>

--- a/functions/function/object-detection-function/README.adoc
+++ b/functions/function/object-detection-function/README.adoc
@@ -28,7 +28,7 @@ Add the `object-detection` dependency to the pom (use the latest version availab
 <dependency>
     <groupId>org.springframework.cloud.fn</groupId>
     <artifactId>object-detection-function</artifactId>
-    <version>${spring-cloud-fn.version}</version>
+    <version>${revision}</version>
 </dependency>
 ----
 

--- a/functions/function/object-detection-function/pom.xml
+++ b/functions/function/object-detection-function/pom.xml
@@ -2,30 +2,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>object-detection-function</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>object-detection-function</name>
-	<description>Spring Native Function for Tensorflow Integration</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-function-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
 
+	<artifactId>object-detection-function</artifactId>
+	<name>object-detection-function</name>
+	<description>Spring Native Function for Tensorflow Integration</description>
+
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>tensorflow-common</artifactId>
-			<version>${spring-cloud-fn.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
-<!--		<dependency>-->
-<!--			<groupId>org.tensorflow</groupId>-->
-<!--			<artifactId>tensorflow-hadoop</artifactId>-->
-<!--			<version>1.15.0</version>-->
-<!--		</dependency>-->
 	</dependencies>
 
 	<build>

--- a/functions/function/payload-converter-function/pom.xml
+++ b/functions/function/payload-converter-function/pom.xml
@@ -3,35 +3,24 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>payload-converter-function</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>payload-converter-function</name>
-	<description>Utility message conversion functions</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-function-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
 
+	<artifactId>payload-converter-function</artifactId>
+	<name>payload-converter-function</name>
+	<description>Utility message conversion functions</description>
+
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-messaging</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 	</dependencies>
 
 </project>

--- a/functions/function/pom.xml
+++ b/functions/function/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.cloud.fn</groupId>
+		<artifactId>java-functions-parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>java-functions-function-parent</artifactId>
+	<name>java-functions-function-parent</name>
+	<description>Pivotal Java Functions Function Parent</description>
+	<packaging>pom</packaging>
+
+  	<modules>
+
+		<module>aggregator-function</module>
+		<module>filter-function</module>
+		<module>header-enricher-function</module>
+		<module>http-request-function</module>
+		<module>spel-function</module>
+		<module>payload-converter-function</module>
+		<module>splitter-function</module>
+		<module>tasklauncher-function</module>
+		<module>task-launch-request-function</module>
+		<module>twitter-function</module>
+		<module>image-recognition-function</module>
+		<module>object-detection-function</module>
+		<module>semantic-segmentation-function</module>
+
+	</modules>
+
+</project>

--- a/functions/function/semantic-segmentation-function/README.adoc
+++ b/functions/function/semantic-segmentation-function/README.adoc
@@ -26,13 +26,13 @@ Add the `semantic-segmentation` dependency to your pom (_use the latest version 
 <dependency>
     <groupId>org.springframework.cloud.fn</groupId>
     <artifactId>semantic-segmentation-function</artifactId>
-    <version>${spring-cloud-fn.version}</version>
+    <version>${revision}</version>
 </dependency>
 
 <dependency>
     <groupId>org.springframework.cloud.fn</groupId>
     <artifactId>object-detection-function</artifactId>
-    <version>${spring-cloud-fn.version}</version>
+    <version>${revision}</version>
 </dependency>
 ----
 

--- a/functions/function/semantic-segmentation-function/pom.xml
+++ b/functions/function/semantic-segmentation-function/pom.xml
@@ -2,31 +2,33 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>semantic-segmentation-function</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>semantic-segmentation-function</name>
-	<description>Spring Native Function for Tensorflow semantic-segmentation integration</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-function-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
+
+	<artifactId>semantic-segmentation-function</artifactId>
+	<name>semantic-segmentation-function</name>
+	<description>Spring Native Function for Tensorflow semantic-segmentation integration</description>
 
 	<properties>
 		<commons-io.version>1.3.2</commons-io.version>
 	</properties>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>tensorflow-common</artifactId>
-			<version>${spring-cloud-fn.version}</version>
+			<version>${project.version}</version>
 		</dependency>
+
 	</dependencies>
 
 	<repositories>
+
 		<repository>
 			<id>tensorflow-snapshots</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -34,5 +36,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
+
 	</repositories>
+
 </project>

--- a/functions/function/spel-function/pom.xml
+++ b/functions/function/spel-function/pom.xml
@@ -2,45 +2,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>spel-function</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>spel-function</name>
-	<description>Spring Native Function for applying SpEL expressions</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-function-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
 
+	<artifactId>spel-function</artifactId>
+	<name>spel-function</name>
+	<description>Spring Native Function for applying SpEL expressions</description>
+
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>payload-converter-function</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-integration</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>provided</scope>
-		</dependency>
 	</dependencies>
 
 </project>

--- a/functions/function/splitter-function/pom.xml
+++ b/functions/function/splitter-function/pom.xml
@@ -2,49 +2,24 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>splitter-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>splitter-function</name>
-    <description>Spring Native Function for Splitter</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-function-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>splitter-function</artifactId>
+    <name>splitter-function</name>
+    <description>Spring Native Function for Splitter</description>
+
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-file</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/functions/function/task-launch-request-function/pom.xml
+++ b/functions/function/task-launch-request-function/pom.xml
@@ -2,36 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-function-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
-
-	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>task-launch-request-function</artifactId>
 	<name>task-launch-request-function</name>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-json</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+
 	</dependencies>
 
 </project>

--- a/functions/function/tasklauncher-function/pom.xml
+++ b/functions/function/tasklauncher-function/pom.xml
@@ -2,28 +2,23 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>tasklauncher-function</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>tasklauncher-function</name>
-    <description>Spring Native Function for applying filter SpEL expressions</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-function-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>tasklauncher-function</artifactId>
+    <name>tasklauncher-function</name>
+    <description>Spring Native Function for applying filter SpEL expressions</description>
 
     <properties>
         <spring.cloud.dataflow.version>2.5.1.RELEASE</spring.cloud.dataflow.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-dataflow-rest-client</artifactId>
@@ -39,17 +34,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/function/twitter-function/pom.xml
+++ b/functions/function/twitter-function/pom.xml
@@ -2,46 +2,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>twitter-function</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
-	<name>twitter-function</name>
-	<description>twitter functions</description>
 
 	<parent>
 		<groupId>org.springframework.cloud.fn</groupId>
-		<artifactId>spring-functions-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../spring-functions-parent</relativePath>
+		<artifactId>java-functions-function-parent</artifactId>
+		<version>${revision}</version>
 	</parent>
 
+	<artifactId>twitter-function</artifactId>
+	<name>twitter-function</name>
+	<description>twitter functions</description>
+
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>twitter-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-integration</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>provided</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.mock-server</groupId>
 			<artifactId>mockserver-netty</artifactId>
@@ -54,6 +33,7 @@
 			<version>5.10</version>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
 
 </project>

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -1,340 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.cloud.stream.app</groupId>
+		<artifactId>stream-applications</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+
 	<groupId>org.springframework.cloud.fn</groupId>
 	<artifactId>java-functions-parent</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<name>java-functions-parent</name>
 	<description>Pivotal Java Functions Parent</description>
 	<packaging>pom</packaging>
 
 	<properties>
-		<java.version>1.8</java.version>
-		<maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
-		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-		<maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
-		<disable.checks>false</disable.checks>
-		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
-		<maven-checkstyle-plugin.failOnViolation>true</maven-checkstyle-plugin.failOnViolation>
-		<maven-checkstyle-plugin.includeTestSourceDirectory>true</maven-checkstyle-plugin.includeTestSourceDirectory>
-		<puppycrawl-tools-checkstyle.version>8.29</puppycrawl-tools-checkstyle.version>
-		<checkstyle.location>https://raw.githubusercontent.com/spring-cloud/stream-applications/master/etc/checkstyle</checkstyle.location>
-		<checkstyle.suppressions.file>
-			${checkstyle.location}/checkstyle-suppressions.xml
-		</checkstyle.suppressions.file>
-		<checkstyle.nohttp.file>
-			${checkstyle.location}/nohttp-checkstyle.xml
-		</checkstyle.nohttp.file>
-		<checkstyle.additional.suppressions.file>
-			${checkstyle.location}/checkstyle-suppressions.xml
-		</checkstyle.additional.suppressions.file>
-		<nohttp-checkstyle.version>0.0.2.RELEASE</nohttp-checkstyle.version>
-		<disable.nohttp.checks>true</disable.nohttp.checks>
-		<spring-javaformat-checkstyle.version>0.0.7</spring-javaformat-checkstyle.version>
+		<revision>1.0.0-SNAPSHOT</revision>
 	</properties>
 
+	<dependencies>
+
+		<!-- Spring Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-json</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-integration</artifactId>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+	</dependencies>
+
   	<modules>
-		<module>common/aws-s3-common</module>
-		<module>common/config-common</module>
-		<module>common/file-common</module>
-		<module>common/ftp-common</module>
-		<module>common/function-test-support</module>
-		<module>common/geode-common</module>
-		<module>common/metadata-store-common</module>
-		<module>common/mqtt-common</module>
-		<module>common/tcp-common</module>
-		<module>common/twitter-common</module>
-		<module>common/tensorflow-common</module>
-		<module>common/cdc-debezium-common</module>
-		<module>common/cdc-debezium-boot-starter</module>
-
-		<module>consumer/cassandra-consumer</module>
-		<module>consumer/elasticsearch-consumer</module>
-		<module>consumer/analytics-consumer</module>
-		<module>consumer/file-consumer</module>
-		<module>consumer/ftp-consumer</module>
-		<module>consumer/geode-consumer</module>
-		<module>consumer/jdbc-consumer</module>
-		<module>consumer/log-consumer</module>
-		<module>consumer/mongodb-consumer</module>
-		<module>consumer/mqtt-consumer</module>
-		<module>consumer/rabbit-consumer</module>
-		<module>consumer/redis-consumer</module>
-		<module>consumer/sftp-consumer</module>
-		<module>consumer/tcp-consumer</module>
-		<module>consumer/websocket-consumer</module>
-		<module>consumer/s3-consumer</module>
-		<module>consumer/twitter-consumer</module>
-		<module>consumer/wavefront-consumer</module>
-		<module>consumer/rsocket-consumer</module>
-
-		<module>function/aggregator-function</module>
-		<module>function/filter-function</module>
-		<module>function/header-enricher-function</module>
-		<module>function/http-request-function</module>
-		<module>function/spel-function</module>
-		<module>function/payload-converter-function</module>
-		<module>function/splitter-function</module>
-		<module>function/tasklauncher-function</module>
-		<module>function/task-launch-request-function</module>
-		<module>function/twitter-function</module>
-		<module>function/image-recognition-function</module>
-		<module>function/object-detection-function</module>
-		<module>function/semantic-segmentation-function</module>
-
-		<module>supplier/file-supplier</module>
-		<module>supplier/ftp-supplier</module>
-		<module>supplier/geode-supplier</module>
-		<module>supplier/http-supplier</module>
-		<module>supplier/jdbc-supplier</module>
-		<module>supplier/jms-supplier</module>
-		<module>supplier/mail-supplier</module>
-		<module>supplier/mongodb-supplier</module>
-		<module>supplier/mqtt-supplier</module>
-		<module>supplier/sftp-supplier</module>
-		<module>supplier/tcp-supplier</module>
-		<module>supplier/time-supplier</module>
-		<module>supplier/rabbit-supplier</module>
-		<module>supplier/websocket-supplier</module>
-		<module>supplier/s3-supplier</module>
-		<module>supplier/twitter-supplier</module>
-		<module>supplier/cdc-debezium-supplier</module>
-		<module>supplier/syslog-supplier</module>
-
-		<module>spring-functions-parent</module>
+		<module>common</module>
+		<module>consumer</module>
+		<module>function</module>
+		<module>supplier</module>
 		<module>function-dependencies</module>
 	</modules>
 
-	<licenses>
-		<license>
-			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
-			<comments>Copyright 2014-2020 the original author or authors.
-
-				Licensed under the Apache License, Version 2.0 (the "License");
-				you may not use this file except in compliance with the License.
-				You may obtain a copy of the License at
-
-				http://www.apache.org/licenses/LICENSE-2.0
-
-				Unless required by applicable law or agreed to in writing, software
-				distributed under the License is distributed on an "AS IS" BASIS,
-				WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-				implied.
-
-				See the License for the specific language governing permissions and
-				limitations under the License.</comments>
-		</license>
-	</licenses>
-	<scm>
-		<connection>scm:git:git://github.com/pivotal/java-functions.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/pivotal/java-functions.git</developerConnection>
-		<url>https://github.com/pivotal/java-functions</url>
-	</scm>
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${maven-javadoc-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>javadoc</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<quiet>true</quiet>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>${maven-source-plugin.version}</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
-				<configuration>
-					<includes>
-						<include>**/*Tests.java</include>
-						<include>**/*Test.java</include>
-					</includes>
-					<excludes>
-						<exclude>**/Abstract*.java</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>${maven-checkstyle-plugin.version}</version>
-				<dependencies>
-					<dependency>
-						<groupId>com.puppycrawl.tools</groupId>
-						<artifactId>checkstyle</artifactId>
-						<version>${puppycrawl-tools-checkstyle.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>io.spring.javaformat</groupId>
-						<artifactId>spring-javaformat-checkstyle</artifactId>
-						<version>${spring-javaformat-checkstyle.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>io.spring.nohttp</groupId>
-						<artifactId>nohttp-checkstyle</artifactId>
-						<version>${nohttp-checkstyle.version}</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>checkstyle-validation</id>
-						<phase>validate</phase>
-						<inherited>true</inherited>
-						<configuration>
-							<skip>${disable.checks}</skip>
-							<configLocation>${checkstyle.location}/checkstyle.xml</configLocation>
-							<headerLocation>${checkstyle.location}/checkstyle-header.txt</headerLocation>
-							<propertyExpansion>
-								checkstyle.build.directory=${project.build.directory}
-								checkstyle.suppressions.file=${checkstyle.suppressions.file}
-								checkstyle.additional.suppressions.file=${checkstyle.additional.suppressions.file}
-							</propertyExpansion>
-							<consoleOutput>true</consoleOutput>
-							<includeTestSourceDirectory>
-								${maven-checkstyle-plugin.includeTestSourceDirectory}
-							</includeTestSourceDirectory>
-							<failsOnError>${maven-checkstyle-plugin.failsOnError}
-							</failsOnError>
-							<failOnViolation>
-								${maven-checkstyle-plugin.failOnViolation}
-							</failOnViolation>
-						</configuration>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>no-http-checkstyle-validation</id>
-						<phase>validate</phase>
-						<inherited>true</inherited>
-						<configuration>
-							<skip>${disable.nohttp.checks}</skip>
-							<configLocation>${checkstyle.nohttp.file}</configLocation>
-							<includes>**/*</includes>
-							<excludes>**/.idea/**/*,**/.git/**/*,**/target/**/*,**/*.log</excludes>
-							<sourceDirectories>./</sourceDirectories>
-						</configuration>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
-	<distributionManagement>
-		<repository>
-			<id>repo.spring.io</id>
-			<name>Spring Release Repository</name>
-			<url>https://repo.spring.io/libs-release-local</url>
-		</repository>
-		<snapshotRepository>
-			<id>repo.spring.io</id>
-			<name>Spring Snapshot Repository</name>
-			<url>https://repo.spring.io/libs-snapshot-local</url>
-		</snapshotRepository>
-	</distributionManagement>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
-
-
-	<profiles>
-		<profile>
-			<id>milestone</id>
-			<distributionManagement>
-				<repository>
-					<id>repo.spring.io</id>
-					<name>Spring Milestone Repository</name>
-					<url>https://repo.spring.io/libs-milestone-local</url>
-				</repository>
-			</distributionManagement>
-		</profile>
-		<profile>
-			<id>central</id>
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-			<distributionManagement>
-				<repository>
-					<id>sonatype-nexus-staging</id>
-					<name>Nexus Release Repository</name>
-					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-				</repository>
-				<snapshotRepository>
-					<id>sonatype-nexus-snapshots</id>
-					<name>Sonatype Nexus Snapshots</name>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-				</snapshotRepository>
-			</distributionManagement>
-		</profile>
-	</profiles>
 </project>

--- a/functions/spring-functions-parent/pom.xml
+++ b/functions/spring-functions-parent/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>java-functions-parent</artifactId>
-		<groupId>org.springframework.cloud.fn</groupId>
-		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
-	</parent>
 	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.cloud.fn</groupId>
+		<artifactId>java-functions-parent</artifactId>
+		<version>${revision}</version>
+	</parent>
 
 	<artifactId>spring-functions-parent</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
@@ -20,30 +20,5 @@
 		<spring-cloud-fn.version>${project.version}</spring-cloud-fn.version>
 		<spring-integration-dependencies.version>5.3.3.BUILD-SNAPSHOT</spring-integration-dependencies.version>
 	</properties>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.integration</groupId>
-				<artifactId>spring-integration-bom</artifactId>
-				<version>${spring-integration-dependencies.version}</version>
-				<scope>import</scope>
-				<type>pom</type>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>${spring-boot.version}</version>
-				<scope>import</scope>
-				<type>pom</type>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-function-dependencies</artifactId>
-				<version>${spring-cloud-function.version}</version>
-				<scope>import</scope>
-				<type>pom</type>
-			</dependency>
-		</dependencies>
 
-	</dependencyManagement>
 </project>

--- a/functions/supplier/cdc-debezium-supplier/pom.xml
+++ b/functions/supplier/cdc-debezium-supplier/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>cdc-debezium-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>cdc-debezium-supplier</name>
-    <description>CDC Debezium Suppliers</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>cdc-debezium-supplier</artifactId>
+    <name>cdc-debezium-supplier</name>
+    <description>CDC Debezium Suppliers</description>
 
     <properties>
         <version.debezium>1.2.1.Final</version.debezium>

--- a/functions/supplier/file-supplier/pom.xml
+++ b/functions/supplier/file-supplier/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>file-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>file-supplier</name>
-    <description>file supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>file-supplier</artifactId>
+    <name>file-supplier</name>
+    <description>file supplier</description>
 
     <dependencies>
         <dependency>

--- a/functions/supplier/ftp-supplier/pom.xml
+++ b/functions/supplier/ftp-supplier/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>ftp-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>ftp-supplier</name>
-    <description>ftp supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>ftp-supplier</artifactId>
+    <name>ftp-supplier</name>
+    <description>ftp supplier</description>
 
     <dependencies>
         <dependency>

--- a/functions/supplier/geode-supplier/pom.xml
+++ b/functions/supplier/geode-supplier/pom.xml
@@ -2,17 +2,17 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>geode-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>geode-supplier</name>
-    <description>geode supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>geode-supplier</artifactId>
+    <name>geode-supplier</name>
+    <description>geode supplier</description>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -27,13 +27,13 @@
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>geode-common</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>config-common</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>function-test-support</artifactId>
-            <version>${spring-cloud-fn.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/functions/supplier/http-supplier/pom.xml
+++ b/functions/supplier/http-supplier/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>http-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>http-supplier</name>
-    <description>HTTP Supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>http-supplier</artifactId>
+    <name>http-supplier</name>
+    <description>HTTP Supplier</description>
 
     <dependencies>
         <dependency>

--- a/functions/supplier/jdbc-supplier/pom.xml
+++ b/functions/supplier/jdbc-supplier/pom.xml
@@ -2,17 +2,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>jdbc-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>jdbc-supplier</name>
-    <description>JDBC supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>jdbc-supplier</artifactId>
+    <name>jdbc-supplier</name>
+    <description>JDBC supplier</description>
 
     <dependencies>
         <dependency>

--- a/functions/supplier/jms-supplier/pom.xml
+++ b/functions/supplier/jms-supplier/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>jms-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>jms-supplier</name>
-    <description>jms supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>jms-supplier</artifactId>
+    <name>jms-supplier</name>
+    <description>jms supplier</description>
 
     <dependencies>
         <dependency>

--- a/functions/supplier/mail-supplier/pom.xml
+++ b/functions/supplier/mail-supplier/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>mail-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>mail-supplier</name>
-    <description>Mail Supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
+
+    <artifactId>mail-supplier</artifactId>
+    <name>mail-supplier</name>
+    <description>Mail Supplier</description>
 
     <dependencies>
         <dependency>

--- a/functions/supplier/mongodb-supplier/pom.xml
+++ b/functions/supplier/mongodb-supplier/pom.xml
@@ -2,67 +2,47 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>mongodb-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>mongodb-supplier</name>
-    <description>Mongo DB supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>mongodb-supplier</artifactId>
+    <name>mongodb-supplier</name>
+    <description>Mongo DB supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-mongodb</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-function-context</artifactId>
             <version>${spring-cloud-function.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>splitter-function</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/supplier/mqtt-supplier/pom.xml
+++ b/functions/supplier/mqtt-supplier/pom.xml
@@ -1,53 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>mqtt-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>mqtt-supplier</name>
-    <description>mqtt supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>mqtt-supplier</artifactId>
+    <name>mqtt-supplier</name>
+    <description>mqtt supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>mqtt-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.9.1</version>
+            <version>${test-containers.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/supplier/pom.xml
+++ b/functions/supplier/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.cloud.fn</groupId>
+		<artifactId>java-functions-parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>java-functions-supplier-parent</artifactId>
+	<name>java-functions-supplier-parent</name>
+	<description>Pivotal Java Functions Supplier Parent</description>
+	<packaging>pom</packaging>
+
+  	<modules>
+
+		<module>file-supplier</module>
+		<module>ftp-supplier</module>
+		<module>geode-supplier</module>
+		<module>http-supplier</module>
+		<module>jdbc-supplier</module>
+		<module>jms-supplier</module>
+		<module>mail-supplier</module>
+		<module>mongodb-supplier</module>
+		<module>mqtt-supplier</module>
+		<module>sftp-supplier</module>
+		<module>tcp-supplier</module>
+		<module>time-supplier</module>
+		<module>rabbit-supplier</module>
+		<module>websocket-supplier</module>
+		<module>s3-supplier</module>
+		<module>twitter-supplier</module>
+		<module>cdc-debezium-supplier</module>
+		<module>syslog-supplier</module>
+
+	</modules>
+
+</project>

--- a/functions/supplier/rabbit-supplier/pom.xml
+++ b/functions/supplier/rabbit-supplier/pom.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>rabbit-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>rabbit-supplier</name>
-    <description>Rabbit supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>rabbit-supplier</artifactId>
+    <name>rabbit-supplier</name>
+    <description>Rabbit supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-amqp</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
@@ -25,30 +26,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/functions/supplier/s3-supplier/pom.xml
+++ b/functions/supplier/s3-supplier/pom.xml
@@ -1,58 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>s3-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>s3-supplier</name>
-    <description>s3 supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>s3-supplier</artifactId>
+    <name>s3-supplier</name>
+    <description>s3 supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>aws-s3-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>file-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>metadata-store-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/supplier/sftp-supplier/pom.xml
+++ b/functions/supplier/sftp-supplier/pom.xml
@@ -1,42 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>sftp-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>sftp-supplier</name>
-    <description>sftp supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>sftp-supplier</artifactId>
+    <name>sftp-supplier</name>
+    <description>sftp supplier</description>
+
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-sftp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud.fn</groupId>
-            <artifactId>file-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud.fn</groupId>
-            <artifactId>ftp-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud.fn</groupId>
-            <artifactId>metadata-store-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-json</artifactId>
@@ -44,33 +21,37 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-sftp</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
+            <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>file-common</artifactId>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>ftp-common</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>metadata-store-common</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>function-test-support</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/supplier/syslog-supplier/pom.xml
+++ b/functions/supplier/syslog-supplier/pom.xml
@@ -1,50 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>syslog-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>syslog-supplier</name>
-    <description>syslog supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>syslog-supplier</artifactId>
+    <name>syslog-supplier</name>
+    <description>syslog supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-syslog</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-test-support</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/supplier/tcp-supplier/pom.xml
+++ b/functions/supplier/tcp-supplier/pom.xml
@@ -1,52 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>tcp-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>tcp-supplier</name>
-    <description>tcp supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>tcp-supplier</artifactId>
+    <name>tcp-supplier</name>
+    <description>tcp supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>tcp-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/functions/supplier/time-supplier/pom.xml
+++ b/functions/supplier/time-supplier/pom.xml
@@ -2,45 +2,29 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>time-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>time-supplier</name>
-    <description>time supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>time-supplier</artifactId>
+    <name>time-supplier</name>
+    <description>time supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/functions/supplier/twitter-supplier/pom.xml
+++ b/functions/supplier/twitter-supplier/pom.xml
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>twitter-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>twitter-supplier</name>
-    <description>twitter suppliers</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>twitter-supplier</artifactId>
+    <name>twitter-supplier</name>
+    <description>twitter suppliers</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>twitter-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-jms</artifactId>
@@ -33,33 +29,10 @@
             <artifactId>javax.jms-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -77,4 +50,5 @@
         </dependency>
 
     </dependencies>
+
 </project>

--- a/functions/supplier/websocket-supplier/pom.xml
+++ b/functions/supplier/websocket-supplier/pom.xml
@@ -1,56 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>websocket-supplier</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>websocket-supplier</name>
-    <description>websocket supplier</description>
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <artifactId>java-functions-supplier-parent</artifactId>
+        <version>${revision}</version>
     </parent>
 
+    <artifactId>websocket-supplier</artifactId>
+    <name>websocket-supplier</name>
+    <description>websocket supplier</description>
+
     <dependencies>
+
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-websocket</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>org.springframework.cloud.stream.app</groupId>
     <artifactId>stream-applications</artifactId>
     <version>3.0.0-SNAPSHOT</version>
@@ -8,9 +9,389 @@
     <description>Functions and Infrastructure for stream applications</description>
     <packaging>pom</packaging>
 
+    <properties>
+        <java.version>1.8</java.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+        <disable.checks>false</disable.checks>
+        <maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
+        <maven-checkstyle-plugin.failOnViolation>true</maven-checkstyle-plugin.failOnViolation>
+        <maven-checkstyle-plugin.includeTestSourceDirectory>true</maven-checkstyle-plugin.includeTestSourceDirectory>
+        <puppycrawl-tools-checkstyle.version>8.29</puppycrawl-tools-checkstyle.version>
+        <checkstyle.location>https://raw.githubusercontent.com/spring-cloud/stream-applications/master/etc/checkstyle</checkstyle.location>
+        <checkstyle.suppressions.file>
+            ${checkstyle.location}/checkstyle-suppressions.xml
+        </checkstyle.suppressions.file>
+        <checkstyle.nohttp.file>
+            ${checkstyle.location}/nohttp-checkstyle.xml
+        </checkstyle.nohttp.file>
+        <checkstyle.additional.suppressions.file>
+            ${checkstyle.location}/checkstyle-suppressions.xml
+        </checkstyle.additional.suppressions.file>
+        <nohttp-checkstyle.version>0.0.2.RELEASE</nohttp-checkstyle.version>
+        <disable.nohttp.checks>true</disable.nohttp.checks>
+        <spring-javaformat-checkstyle.version>0.0.7</spring-javaformat-checkstyle.version>
+        <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
+        <spring-cloud-function.version>3.0.9.RELEASE</spring-cloud-function.version>
+        <spring-integration-dependencies.version>5.3.3.BUILD-SNAPSHOT</spring-integration-dependencies.version>
+        <test-containers.version>1.15.0-rc2</test-containers.version>
+    </properties>
+
     <modules>
         <module>functions</module>
         <module>applications</module>
 	</modules>
+
+    <dependencies>
+
+        <!-- Spring Boot dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spring Cloud dependencies -->
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <dependencyManagement>
+
+        <dependencies>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.integration</groupId>
+                <artifactId>spring-integration-bom</artifactId>
+                <version>${spring-integration-dependencies.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-function-dependencies</artifactId>
+                <version>${spring-cloud-function.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
+
+    <build>
+
+        <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.5</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>javadoc</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <quiet>true</quiet>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Tests.java</include>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/Abstract*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${puppycrawl-tools-checkstyle.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.spring.javaformat</groupId>
+                        <artifactId>spring-javaformat-checkstyle</artifactId>
+                        <version>${spring-javaformat-checkstyle.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.spring.nohttp</groupId>
+                        <artifactId>nohttp-checkstyle</artifactId>
+                        <version>${nohttp-checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>checkstyle-validation</id>
+                        <phase>validate</phase>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <skip>${disable.checks}</skip>
+                            <configLocation>${checkstyle.location}/checkstyle.xml</configLocation>
+                            <headerLocation>${checkstyle.location}/checkstyle-header.txt</headerLocation>
+                            <propertyExpansion>
+                                checkstyle.build.directory=${project.build.directory}
+                                checkstyle.suppressions.file=${checkstyle.suppressions.file}
+                                checkstyle.additional.suppressions.file=${checkstyle.additional.suppressions.file}
+                            </propertyExpansion>
+                            <consoleOutput>true</consoleOutput>
+                            <includeTestSourceDirectory>
+                                ${maven-checkstyle-plugin.includeTestSourceDirectory}
+                            </includeTestSourceDirectory>
+                            <failsOnError>${maven-checkstyle-plugin.failsOnError}
+                            </failsOnError>
+                            <failOnViolation>
+                                ${maven-checkstyle-plugin.failOnViolation}
+                            </failOnViolation>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>no-http-checkstyle-validation</id>
+                        <phase>validate</phase>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <skip>${disable.nohttp.checks}</skip>
+                            <configLocation>${checkstyle.nohttp.file}</configLocation>
+                            <includes>**/*</includes>
+                            <excludes>**/.idea/**/*,**/.git/**/*,**/target/**/*,**/*.log</excludes>
+                            <sourceDirectories>./</sourceDirectories>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+    <licenses>
+
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <comments>Copyright 2014-2020 the original author or authors.
+
+                Licensed under the Apache License, Version 2.0 (the "License");
+                you may not use this file except in compliance with the License.
+                You may obtain a copy of the License at
+
+                http://www.apache.org/licenses/LICENSE-2.0
+
+                Unless required by applicable law or agreed to in writing, software
+                distributed under the License is distributed on an "AS IS" BASIS,
+                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+                implied.
+
+                See the License for the specific language governing permissions and
+                limitations under the License.</comments>
+        </license>
+
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/pivotal/java-functions.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/pivotal/java-functions.git</developerConnection>
+        <url>https://github.com/pivotal/java-functions</url>
+    </scm>
+
+    <distributionManagement>
+
+        <repository>
+            <id>repo.spring.io</id>
+            <name>Spring Release Repository</name>
+            <url>https://repo.spring.io/libs-release-local</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>repo.spring.io</id>
+            <name>Spring Snapshot Repository</name>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
+        </snapshotRepository>
+
+    </distributionManagement>
+
+    <repositories>
+
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+
+    </repositories>
+
+    <pluginRepositories>
+
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+        </pluginRepository>
+
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+
+    </pluginRepositories>
+
+    <profiles>
+
+        <profile>
+            <id>milestone</id>
+            <distributionManagement>
+                <repository>
+                    <id>repo.spring.io</id>
+                    <name>Spring Milestone Repository</name>
+                    <url>https://repo.spring.io/libs-milestone-local</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+
+        <profile>
+            <id>central</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <distributionManagement>
+                <repository>
+                    <id>sonatype-nexus-staging</id>
+                    <name>Nexus Release Repository</name>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>sonatype-nexus-snapshots</id>
+                    <name>Sonatype Nexus Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+
+    </profiles>
 
 </project>


### PR DESCRIPTION
refactor hardcoded versions in `functions` submodule branches

This is so they can be updated in a minimal amount of places and leverage the maven hierarchy to propagate them where appropriate. While working with SNAPSHOT releases of Spring Boot, Spring Integration, and Spring Cloud, it required touching every `pom.xml` file in order to reflect the use of the SNAPSHOT. After this change, it will only be required to change the property in the top `functions` pom.xml and the versions will reflect to all submodules.

Maven introduced the ability use a key property, `revision` to propagate this information to the `<parent>` declarations in each pom.

This was enabled in Maven 3.5+
https://maven.apache.org/maven-ci-friendly.html