### PR TITLE
GH-156: Fix NPE in the `RemoteFileDeletingAdvice`

### DIFF
--- a/applications/source/sftp-source/src/test/java/org/springframework/cloud/stream/app/source/sftp/SftpSourceTests.java
+++ b/applications/source/sftp-source/src/test/java/org/springframework/cloud/stream/app/source/sftp/SftpSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ public class SftpSourceTests extends SftpTestSupport {
 						"sftp.supplier.factory.port =${sftp.factory.port}",
 						"sftp.supplier.factory.allowUnknownKeys=true",
 						"sftp.supplier.remoteDir=sftpSource",
+						"sftp.supplier.delete-remote-files=true",
 						"spring.cloud.function.definition=sftpSupplier")
 				.run(context -> {
 					OutputDestination output = context.getBean(OutputDestination.class);

--- a/functions/common/file-common/src/main/java/org/springframework/cloud/fn/common/file/remote/RemoteFileDeletingAdvice.java
+++ b/functions/common/file-common/src/main/java/org/springframework/cloud/fn/common/file/remote/RemoteFileDeletingAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,14 @@ import org.springframework.integration.aop.MessageSourceMutator;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
  * A {@link MessageSourceMutator} that deletes a remote file on success.
  *
  * @author David Turanski
+ * @author Artem Bilan
  *
  */
 public class RemoteFileDeletingAdvice implements MessageSourceMutator {
@@ -45,11 +47,14 @@ public class RemoteFileDeletingAdvice implements MessageSourceMutator {
 		this.remoteFileSeparator = remoteFileSeparator;
 	}
 
+	@Nullable
 	@Override
-	public Message<?> afterReceive(Message<?> result, MessageSource<?> source) {
-		String remoteDir = (String) result.getHeaders().get(FileHeaders.REMOTE_DIRECTORY);
-		String remoteFile = (String) result.getHeaders().get(FileHeaders.REMOTE_FILE);
-		this.template.remove(remoteDir + this.remoteFileSeparator + remoteFile);
+	public Message<?> afterReceive(@Nullable Message<?> result, MessageSource<?> source) {
+		if (result != null) {
+			String remoteDir = (String) result.getHeaders().get(FileHeaders.REMOTE_DIRECTORY);
+			String remoteFile = (String) result.getHeaders().get(FileHeaders.REMOTE_FILE);
+			this.template.remove(remoteDir + this.remoteFileSeparator + remoteFile);
+		}
 		return result;
 	}
 }

--- a/functions/supplier/sftp-supplier/src/test/java/org/springframework/cloud/fn/supplier/sftp/SftpSupplierApplicationTests.java
+++ b/functions/supplier/sftp-supplier/src/test/java/org/springframework/cloud/fn/supplier/sftp/SftpSupplierApplicationTests.java
@@ -243,6 +243,7 @@ public class SftpSupplierApplicationTests extends SftpTestSupport {
 						"sftp.supplier.factory.private-key = classpath:id_rsa_pp",
 						"sftp.supplier.factory.passphrase = secret",
 						"sftp.supplier.factory.password = badPassword", // ensure public key was used
+						"sftp.supplier.delete-remote-files=true",
 						"file.consumer.mode=lines",
 						"file.consumer.with-markers=true",
 						"file.consumer.markers-json=true")


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/156

The `MessageSource.receive()` may produce `null`:
The `MessageSourceMutator` impl must honor such an input

* Add `MonoProcessor<Boolean> subscriptionBarrier` to delay
subscription to the source `Flux` until subscription happens
to the supplier's flux.
This way we don't have unexpected interaction with the source when
there are regular endpoints in the flow in between