### PR TITLE
Refactor the usage of output channel in suppliers

### DIFF
--- a/functions/supplier/mail-supplier/src/main/java/org/springframework/cloud/fn/supplier/mail/MailSupplierConfiguration.java
+++ b/functions/supplier/mail-supplier/src/main/java/org/springframework/cloud/fn/supplier/mail/MailSupplierConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class MailSupplierConfiguration {
 
 	@Bean
 	public Supplier<Flux<Message<?>>> mailSupplier(@Qualifier("mailChannelAdapter") MessageProducerSupport mailChannelAdapter) {
-		return () -> Flux.from(output())
+		return () -> Flux.from(mailInputChannel())
 				.doOnSubscribe(subscription -> mailChannelAdapter.start());
 	}
 
@@ -77,12 +77,12 @@ public class MailSupplierConfiguration {
 							.header(MailHeaders.CC, arrayToListProcessor(MailHeaders.CC))
 							.header(MailHeaders.BCC, arrayToListProcessor(MailHeaders.BCC));
 				})
-				.channel(output())
+				.channel(mailInputChannel())
 				.get();
 	}
 
 	@Bean
-	public FluxMessageChannel output() {
+	public FluxMessageChannel mailInputChannel() {
 		return new FluxMessageChannel();
 	}
 

--- a/functions/supplier/syslog-supplier/src/main/java/org/springframework/cloud/fn/supplier/syslog/SyslogSupplierConfiguration.java
+++ b/functions/supplier/syslog-supplier/src/main/java/org/springframework/cloud/fn/supplier/syslog/SyslogSupplierConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,16 +55,16 @@ public class SyslogSupplierConfiguration {
 	private SyslogSupplierProperties properties;
 
 	@Bean
-	public FluxMessageChannel output() {
+	public FluxMessageChannel syslogInputChannel() {
 		return new FluxMessageChannel();
 	}
 
 	@Bean
-	public Supplier<Flux<Message<?>>> syslogSupplier(ObjectProvider<UdpSyslogReceivingChannelAdapter> udpApapterProvider,
+	public Supplier<Flux<Message<?>>> syslogSupplier(ObjectProvider<UdpSyslogReceivingChannelAdapter> udpAdapterProvider,
 												ObjectProvider<TcpSyslogReceivingChannelAdapter> tcpAdapterProvider) {
-		return () -> Flux.from(output())
+		return () -> Flux.from(syslogInputChannel())
 				.doOnSubscribe(subscription -> {
-					final UdpSyslogReceivingChannelAdapter udpAdapter = udpApapterProvider.getIfAvailable();
+					final UdpSyslogReceivingChannelAdapter udpAdapter = udpAdapterProvider.getIfAvailable();
 					final TcpSyslogReceivingChannelAdapter tcpAdapter = tcpAdapterProvider.getIfAvailable();
 					if (udpAdapter != null) {
 						udpAdapter.start();
@@ -127,7 +127,7 @@ public class SyslogSupplierConfiguration {
 	private void setAdapterProperties(SyslogReceivingChannelAdapterSupport adapter) {
 		adapter.setPort(this.properties.getPort());
 		adapter.setConverter(syslogConverter());
-		adapter.setOutputChannel(output());
+		adapter.setOutputChannel(syslogInputChannel());
 		adapter.setAutoStartup(false);
 	}
 


### PR DESCRIPTION
Redesigning suppliers that use reactive output channel name as
the literal "output" explicitly, as this  cuases some conflicts
with the output channel name usage in Spring Cloud Stream.
The fix is done either by simply renaming the channel name
or by avoid using it directly, but delegate its use through the SI Java DSL.

Resolves https://github.com/spring-cloud/stream-applications/issues/160