### PR TITLE
GH-171: Fix security tests for actuator endpoints

### DIFF
--- a/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/ReactiveSecurityEnabledManagementSecurityEnabledTests.java
+++ b/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/ReactiveSecurityEnabledManagementSecurityEnabledTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.cloud.stream.app.security.common;
 
 import java.util.Map;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.http.HttpStatus;
@@ -51,13 +50,9 @@ public class ReactiveSecurityEnabledManagementSecurityEnabledTests extends Abstr
 
 	@Test
 	@SuppressWarnings("rawtypes")
-	@Disabled
 	public void testInfoEndpoint() {
 		ResponseEntity<Map> response = this.restTemplate.getForEntity("/actuator/info", Map.class);
-		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(response.hasBody()).isTrue();
-		Map info = response.getBody();
-		assertThat(info.get("name")).isEqualTo("MY TEST APP");
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 	}
 
 	// The ManagementWebSecurityAutoConfiguration exposes only Info and Health endpoint not Env!

--- a/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/SecurityEnabledManagementSecurityEnabledTests.java
+++ b/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/SecurityEnabledManagementSecurityEnabledTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.cloud.stream.app.security.common;
 
 import java.util.Map;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.http.HttpStatus;
@@ -50,13 +49,9 @@ public class SecurityEnabledManagementSecurityEnabledTests extends AbstractSecur
 
 	@Test
 	@SuppressWarnings("rawtypes")
-	@Disabled
 	public void testInfoEndpoint() {
 		ResponseEntity<Map> response = this.restTemplate.getForEntity("/actuator/info", Map.class);
-		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(response.hasBody()).isTrue();
-		Map info = response.getBody();
-		assertThat(info.get("name")).isEqualTo("MY TEST APP");
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 	}
 
 	// The ManagementWebSecurityAutoConfiguration exposes only Info and Health endpoint not Env!


### PR DESCRIPTION
Related to: https://github.com/spring-cloud/stream-applications/issues/171

The `/info` is not unsecured any more starting with Spring Boot `2.5`:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#secure-info-endpoint