### PR TITLE
Break dependence on RabbitAutoConfiguration

### DIFF
--- a/applications/processor/aggregator-processor/README.adoc
+++ b/applications/processor/aggregator-processor/README.adoc
@@ -30,7 +30,6 @@ $$authentication-database$$:: $$Authentication database name.$$ *($$String$$, de
 $$auto-index-creation$$:: $$Whether to enable auto-index creation.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$database$$:: $$Database name.$$ *($$String$$, default: `$$<none>$$`)*
 $$field-naming-strategy$$:: $$Fully qualified name of the FieldNamingStrategy to use.$$ *($$Class<?>$$, default: `$$<none>$$`)*
-$$grid-fs-database$$:: $$<documentation missing>$$ *($$String$$, default: `$$<none>$$`)*
 $$host$$:: $$Mongo server host. Cannot be set with URI.$$ *($$String$$, default: `$$<none>$$`)*
 $$password$$:: $$Login password of the mongo server. Cannot be set with URI.$$ *($$Character[]$$, default: `$$<none>$$`)*
 $$port$$:: $$Mongo server port. Cannot be set with URI.$$ *($$Integer$$, default: `$$<none>$$`)*
@@ -46,7 +45,7 @@ $$data$$:: $$Data (DML) script resource references.$$ *($$List<String>$$, defaul
 $$data-password$$:: $$Password of the database to execute DML scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
 $$data-username$$:: $$Username of the database to execute DML scripts (if different).$$ *($$String$$, default: `$$<none>$$`)*
 $$driver-class-name$$:: $$Fully qualified name of the JDBC driver. Auto-detected based on the URL by default.$$ *($$String$$, default: `$$<none>$$`)*
-$$embedded-database-connection$$:: $$Connection details for an embedded database. Defaults to the most suitable embedded database that is available on the classpath.$$ *($$EmbeddedDatabaseConnection$$, default: `$$<none>$$`, possible values: `NONE`,`H2`,`DERBY`,`HSQL`,`HSQLDB`)*
+$$embedded-database-connection$$:: $$Connection details for an embedded database. Defaults to the most suitable embedded database that is available on the classpath.$$ *($$EmbeddedDatabaseConnection$$, default: `$$<none>$$`, possible values: `NONE`,`H2`,`DERBY`,`HSQLDB`)*
 $$generate-unique-name$$:: $$Whether to generate a random datasource name.$$ *($$Boolean$$, default: `$$true$$`)*
 $$initialization-mode$$:: $$Mode to apply when determining if DataSource initialization should be performed using the available DDL and DML scripts.$$ *($$DataSourceInitializationMode$$, default: `$$embedded$$`, possible values: `ALWAYS`,`EMBEDDED`,`NEVER`)*
 $$jndi-name$$:: $$JNDI location of the datasource. Class, url, username and password are ignored when set.$$ *($$String$$, default: `$$<none>$$`)*
@@ -65,7 +64,7 @@ $$username$$:: $$Login username of the database.$$ *($$String$$, default: `$$<no
 === spring.mongodb.embedded
 
 $$features$$:: $$Comma-separated list of features to enable. Uses the defaults of the configured version by default.$$ *($$Set<Feature>$$, default: `$$[sync_delay]$$`)*
-$$version$$:: $$Version of Mongo to use.$$ *($$String$$, default: `$$3.5.5$$`)*
+$$version$$:: $$Version of Mongo to use.$$ *($$String$$, default: `$$<none>$$`)*
 
 === spring.redis
 

--- a/applications/sink/redis-sink/README.adoc
+++ b/applications/sink/redis-sink/README.adoc
@@ -36,6 +36,7 @@ $$username$$:: $$Login username of the redis server.$$ *($$String$$, default: `$
 
 === spring.redis.jedis.pool
 
+$$enabled$$:: $$Whether to enable the pool. Enabled automatically if "commons-pool2" is available.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$max-active$$:: $$Maximum number of connections that can be allocated by the pool at a given time. Use a negative value for no limit.$$ *($$Integer$$, default: `$$8$$`)*
 $$max-idle$$:: $$Maximum number of "idle" connections in the pool. Use a negative value to indicate an unlimited number of idle connections.$$ *($$Integer$$, default: `$$8$$`)*
 $$max-wait$$:: $$Maximum amount of time a connection allocation should block before throwing an exception when the pool is exhausted. Use a negative value to block indefinitely.$$ *($$Duration$$, default: `$$-1ms$$`)*
@@ -44,6 +45,7 @@ $$time-between-eviction-runs$$:: $$Time between runs of the idle object evictor 
 
 === spring.redis.lettuce.pool
 
+$$enabled$$:: $$Whether to enable the pool. Enabled automatically if "commons-pool2" is available.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$max-active$$:: $$Maximum number of connections that can be allocated by the pool at a given time. Use a negative value for no limit.$$ *($$Integer$$, default: `$$8$$`)*
 $$max-idle$$:: $$Maximum number of "idle" connections in the pool. Use a negative value to indicate an unlimited number of idle connections.$$ *($$Integer$$, default: `$$8$$`)*
 $$max-wait$$:: $$Maximum amount of time a connection allocation should block before throwing an exception when the pool is exhausted. Use a negative value to block indefinitely.$$ *($$Duration$$, default: `$$-1ms$$`)*

--- a/applications/sink/redis-sink/src/test/java/org/springframework/cloud/stream/app/sink/redis/RedisSinkTests.java
+++ b/applications/sink/redis-sink/src/test/java/org/springframework/cloud/stream/app/sink/redis/RedisSinkTests.java
@@ -50,6 +50,7 @@ public class RedisSinkTests {
 						.getCompleteConfiguration(RedisSinkTestApplication.class))
 				.web(WebApplicationType.NONE)
 				.run("--spring.cloud.function.definition=redisConsumer",
+						"--spring.cloud.compatibility-verifier.enabled=false",
 						"--redis.consumer.key=foo")) {
 
 			//Setup

--- a/functions/consumer/mongodb-consumer/src/test/java/org/springframework/cloud/fn/consumer/mongo/MongoDbConsumerApplicationTests.java
+++ b/functions/consumer/mongodb-consumer/src/test/java/org/springframework/cloud/fn/consumer/mongo/MongoDbConsumerApplicationTests.java
@@ -42,6 +42,7 @@ import static org.awaitility.Awaitility.await;
  */
 @SpringBootTest(properties = {
 		"spring.data.mongodb.port=0",
+		"spring.mongodb.embedded.version=4.0.12",
 		"mongodb.consumer.collection=testing" })
 class MongoDbConsumerApplicationTests {
 

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  */
 @TestPropertySource(properties = {
+		"spring.mongodb.embedded.version=4.0.12",
 		"aggregator.correlation=T(Thread).currentThread().id",
 		"aggregator.release=!messages.?[payload == 'bar'].empty",
 		"aggregator.aggregation=#this.?[payload == 'foo'].![payload]",

--- a/functions/spring-functions-parent/pom.xml
+++ b/functions/spring-functions-parent/pom.xml
@@ -15,7 +15,6 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<spring-boot.version>2.6.0-M1</spring-boot.version>
 		<spring-cloud-function.version>3.1.4-SNAPSHOT</spring-cloud-function.version>
 		<spring-cloud-fn.version>${project.version}</spring-cloud-fn.version>
 	</properties>

--- a/functions/spring-functions-parent/pom.xml
+++ b/functions/spring-functions-parent/pom.xml
@@ -15,6 +15,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
+		<spring-boot.version>2.6.0-M1</spring-boot.version>
 		<spring-cloud-function.version>3.1.4-SNAPSHOT</spring-cloud-function.version>
 		<spring-cloud-fn.version>${project.version}</spring-cloud-fn.version>
 	</properties>

--- a/functions/supplier/mongodb-supplier/src/test/java/org/springframework/cloud/fn/supplier/mongo/MongodbSupplierApplicationTests.java
+++ b/functions/supplier/mongodb-supplier/src/test/java/org/springframework/cloud/fn/supplier/mongo/MongodbSupplierApplicationTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.entry;
 
 @SpringBootTest(properties = {
 		"spring.data.mongodb.port=0",
+		"spring.mongodb.embedded.version=4.0.12",
 		"mongodb.supplier.collection=testing",
 		"mongodb.supplier.query={ name: { $exists: true }}",
 		"mongodb.supplier.update-expression='{ $unset: { name: 0 } }'"

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -40,7 +40,7 @@
 		<nohttp-checkstyle.version>0.0.2.RELEASE</nohttp-checkstyle.version>
 		<disable.nohttp.checks>true</disable.nohttp.checks>
 		<spring-javaformat-checkstyle.version>0.0.7</spring-javaformat-checkstyle.version>
-		<spring-boot.version>2.5.4-SNAPSHOT</spring-boot.version>
+		<spring-boot.version>2.6.0-M1</spring-boot.version>
 		<spring-kafka.version>2.7.1</spring-kafka.version>
 		<spring-rabbit.version>2.3.7</spring-rabbit.version>
 		<spring-cloud-function.version>3.1.4-SNAPSHOT</spring-cloud-function.version>


### PR DESCRIPTION
This code proposal breaks the dependence on [RabbitAutoConfiguration](https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/187#issuecomment-860227374) for the `rabbit-consumer` and `rabbit-supplier` functions. 

> ⚠️ The [changes that make this possible](https://github.com/spring-projects/spring-boot/pull/26982) are in **2.6** branch of Spring Boot. I am sure that the team would prefer to have a separate pull request for upgrading to 2.6 rather than piggyback it in w/ this change. Please advise and I will pivot as requested. 

@sabbyanandan @garyrussell this is the `streams-application` counterpart to the [spring-cloud-stream-rabbit-binder](https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/pull/323) one. 
