### PR TITLE
Fix mysql compatibility with jdk8_301

### DIFF
--- a/applications/source/cdc-debezium-source/src/test/java/org/springframework/cloud/stream/app/source/cdc/CdcMySqlTestSupport.java
+++ b/applications/source/cdc-debezium-source/src/test/java/org/springframework/cloud/stream/app/source/cdc/CdcMySqlTestSupport.java
@@ -51,7 +51,7 @@ public abstract class CdcMySqlTestSupport {
 		MAPPED_PORT = String.valueOf(debeziumMySQL.getMappedPort(3306));
 		jdbcTemplate = CdcTestUtils.jdbcTemplate(
 				"com.mysql.cj.jdbc.Driver",
-				"jdbc:mysql://localhost:" + MAPPED_PORT + "/" + DATABASE_NAME,
+				"jdbc:mysql://localhost:" + MAPPED_PORT + "/" + DATABASE_NAME + "?enabledTLSProtocols=TLSv1.2",
 				"root",
 				"debezium");
 	}


### PR DESCRIPTION
 Latest jdk8#301 disables TLS 1.0/1.1 used by default by the not up-to-date mysql jdbc connectors.
 This leads to errors like this: `javax.net.ssl.SSLHandshakeException:No appropriate protocol`.
 A workaround is to set the enabledTLSProtocols=TLSv1.2 jdbc url parameter explicitly.