### PR TITLE
Enable actuator discovery

### DIFF
--- a/applications/stream-applications-core/stream-applications-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/AppStarterWebFluxSecurityAutoConfiguration.java
+++ b/applications/stream-applications-core/stream-applications-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/AppStarterWebFluxSecurityAutoConfiguration.java
@@ -61,7 +61,7 @@ public class AppStarterWebFluxSecurityAutoConfiguration {
 					.permitAll();
 		}
 		else {
-			http.authorizeExchange().pathMatchers("/actuator/health", "/actuator/info", "/actuator/bindings")
+			http.authorizeExchange().pathMatchers("/actuator", "/actuator/health", "/actuator/info", "/actuator/bindings")
 					.permitAll().anyExchange().authenticated();
 			http.httpBasic();
 			http.formLogin();

--- a/applications/stream-applications-core/stream-applications-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/AppStarterWebSecurityAutoConfiguration.java
+++ b/applications/stream-applications-core/stream-applications-security-common/src/main/java/org/springframework/cloud/stream/app/security/common/AppStarterWebSecurityAutoConfiguration.java
@@ -60,6 +60,7 @@ public class AppStarterWebSecurityAutoConfiguration {
 				}
 				if (securityProperties.isEnabled()) {
 					http.authorizeRequests()
+							.requestMatchers(EndpointRequest.toLinks()).permitAll()
 							.requestMatchers(EndpointRequest.to("health", "info", "bindings")).permitAll()
 							.requestMatchers(EndpointRequest.toAnyEndpoint()).authenticated()
 							.and().formLogin().and().httpBasic();

--- a/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/ReactiveSecurityEnabledManagementSecurityEnabledTests.java
+++ b/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/ReactiveSecurityEnabledManagementSecurityEnabledTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @TestPropertySource(properties = {
 		"spring.main.web-application-type=reactive",
+		"management.endpoints.web.discovery.enabled=true",
 		"management.endpoints.web.exposure.include=health,info,env,bindings",
 		"info.name=MY TEST APP"})
 public class ReactiveSecurityEnabledManagementSecurityEnabledTests extends AbstractSecurityCommonTests {
@@ -54,6 +55,13 @@ public class ReactiveSecurityEnabledManagementSecurityEnabledTests extends Abstr
 	@SuppressWarnings("rawtypes")
 	public void testInfoEndpoint() {
 		ResponseEntity<Map> response = this.restTemplate.getForEntity("/actuator/info", Map.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void testDiscoveryEndpoint() {
+		ResponseEntity<Map> response = this.restTemplate.getForEntity("/actuator", Map.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}
 

--- a/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/SecurityEnabledManagementSecurityEnabledTests.java
+++ b/applications/stream-applications-core/stream-applications-security-common/src/test/java/org/springframework/cloud/stream/app/security/common/SecurityEnabledManagementSecurityEnabledTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @TestPropertySource(properties = {
 		"spring.main.web-application-type=servlet",
+		"management.endpoints.web.discovery.enabled=true",
 		"management.endpoints.web.exposure.include=health,info,env",
 		"info.name=MY TEST APP"})
 public class SecurityEnabledManagementSecurityEnabledTests extends AbstractSecurityCommonTests {
@@ -51,6 +52,13 @@ public class SecurityEnabledManagementSecurityEnabledTests extends AbstractSecur
 	@SuppressWarnings("rawtypes")
 	public void testInfoEndpoint() {
 		ResponseEntity<Map> response = this.restTemplate.getForEntity("/actuator/info", Map.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void testDiscoveryEndpoint() {
+		ResponseEntity<Map> response = this.restTemplate.getForEntity("/actuator", Map.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 	}
 


### PR DESCRIPTION
This will expose the root `/actuator` endpoint if `management.endpoints.web.discovery.enabled=true`. There is another PR on the apps generator plugin to set the property to true by default.