### PR TITLE
GH-183: Expose MQTT SSL properties

### DIFF
--- a/functions/common/mqtt-common/pom.xml
+++ b/functions/common/mqtt-common/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>mqtt-common</artifactId>
     <name>mqtt-common</name>
-    <description>file consumer</description>
+    <description>MQTT Common</description>
 
     <dependencies>
 

--- a/functions/common/mqtt-common/src/main/java/org/springframework/cloud/fn/common/mqtt/MqttConfiguration.java
+++ b/functions/common/mqtt-common/src/main/java/org/springframework/cloud/fn/common/mqtt/MqttConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.fn.common.mqtt;
 
+import java.util.Map;
+import java.util.Properties;
+
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
@@ -31,7 +34,7 @@ import org.springframework.util.ObjectUtils;
  * Generic mqtt configuration.
  *
  * @author Janne Valkealahti
- *
+ * @author Artem Bilan
  */
 @Configuration
 public class MqttConfiguration {
@@ -50,6 +53,14 @@ public class MqttConfiguration {
 		mqttConnectOptions.setConnectionTimeout(mqttProperties.getConnectionTimeout());
 		mqttConnectOptions.setKeepAliveInterval(mqttProperties.getKeepAliveInterval());
 
+		Map<String, String> sslProperties = mqttProperties.getSslProperties();
+
+		if (!sslProperties.isEmpty()) {
+			Properties sslProps = new Properties();
+			sslProps.putAll(sslProperties);
+			mqttConnectOptions.setSSLProperties(sslProps);
+		}
+
 		DefaultMqttPahoClientFactory factory = new DefaultMqttPahoClientFactory();
 		factory.setConnectionOptions(mqttConnectOptions);
 
@@ -61,4 +72,5 @@ public class MqttConfiguration {
 		}
 		return factory;
 	}
+
 }

--- a/functions/common/mqtt-common/src/main/java/org/springframework/cloud/fn/common/mqtt/MqttProperties.java
+++ b/functions/common/mqtt-common/src/main/java/org/springframework/cloud/fn/common/mqtt/MqttProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.fn.common.mqtt;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.validation.constraints.Size;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -25,7 +28,7 @@ import org.springframework.validation.annotation.Validated;
  * Generic mqtt connection properties.
  *
  * @author Janne Valkealahti
- *
+ * @author Artem Bilan
  */
 @Validated
 @ConfigurationProperties("mqtt")
@@ -70,6 +73,11 @@ public class MqttProperties {
 	 * Persistence directory.
 	 */
 	private String persistenceDirectory = "/tmp/paho";
+
+	/**
+	 * MQTT Client SSL properties.
+	 */
+	private final Map<String, String> sslProperties = new HashMap<>();
 
 	@Size(min = 1)
 	public String[] getUrl() {
@@ -135,4 +143,9 @@ public class MqttProperties {
 	public void setPersistenceDirectory(String persistenceDirectory) {
 		this.persistenceDirectory = persistenceDirectory;
 	}
+
+	public Map<String, String> getSslProperties() {
+		return this.sslProperties;
+	}
+
 }

--- a/functions/consumer/mqtt-consumer/README.adoc
+++ b/functions/consumer/mqtt-consumer/README.adoc
@@ -16,6 +16,12 @@ All configuration properties are prefixed with `mqtt.consumer`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/consumer/mqtt/MqttConsumerProperties.java[MqttConsumerProperties].
 
+## SSL Configuration
+
+The MQTT Paho client can accept an SSL configuration via `MqttConnectOptions.setSSLProperties()`.
+These properties are exposed on the `MqttProperties.sslProperties` map.
+The keys for these SSL properties should be taken from the `org.eclipse.paho.client.mqttv3.internal.security.SSLSocketFactoryFactory` constants, which all start with the `com.ibm.ssl.` prefix.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/consumer/mqtt/MqttConsumerTests.java[test suite] for the various ways, this consumer is used.

--- a/functions/supplier/mqtt-supplier/README.adoc
+++ b/functions/supplier/mqtt-supplier/README.adoc
@@ -24,6 +24,12 @@ All configuration properties are prefixed with `mqtt.supplier` and `mqtt`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/mqtt/MqttSupplierProperties.java[MqttSupplierProperties].
 
+## SSL Configuration
+
+The MQTT Paho client can accept an SSL configuration via `MqttConnectOptions.setSSLProperties()`.
+These properties are exposed on the `MqttProperties.sslProperties` map.
+The keys for these SSL properties should be taken from the `org.eclipse.paho.client.mqttv3.internal.security.SSLSocketFactoryFactory` constants, which all start with the `com.ibm.ssl.` prefix.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/mqtt/MqttSupplierTests.java[test suite] for the various ways, this supplier is used.


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/183

* Add `MqttProperties.sslProperties` common MQTT configuration property as a `Map` structure
* Delegate a content fo the `MqttProperties.sslProperties` into `mqttConnectOptions.setSSLProperties()`
in the common `MqttConfiguration`
* Verify that SSL properties are applied in both `MqttSupplierTests` & `MqttConsumerTests`
* Document a new `MqttProperties.sslProperties` configuration property for both consumer and supplier
* Use `eclipse-mosquitto` Docker image for MQTT tests instead of RabbitMQ plugin: the Mosquitto starts much faster