### PR TITLE
GH-182: Upgrade Debezium to 1.7.1

### DIFF
--- a/applications/sink/mqtt-sink/README.adoc
+++ b/applications/sink/mqtt-sink/README.adoc
@@ -24,6 +24,7 @@ $$keep-alive-interval$$:: $$the ping interval in seconds.$$ *($$Integer$$, defau
 $$password$$:: $$the password to use when connecting to the broker.$$ *($$String$$, default: `$$guest$$`)*
 $$persistence$$:: $$'memory' or 'file'.$$ *($$String$$, default: `$$memory$$`)*
 $$persistence-directory$$:: $$Persistence directory.$$ *($$String$$, default: `$$/tmp/paho$$`)*
+$$ssl-properties$$:: $$MQTT Client SSL properties.$$ *($$Map<String, String>$$, default: `$$<none>$$`)*
 $$url$$:: $$location of the mqtt broker(s) (comma-delimited list).$$ *($$String[]$$, default: `$$[tcp://localhost:1883]$$`)*
 $$username$$:: $$the username to use when connecting to the broker.$$ *($$String$$, default: `$$guest$$`)*
 

--- a/applications/source/cdc-debezium-source/pom.xml
+++ b/applications/source/cdc-debezium-source/pom.xml
@@ -26,21 +26,6 @@
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>cdc-debezium-supplier</artifactId>
 			<version>${java-functions.version}</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>slf4j-log4j12</artifactId>
-					<groupId>org.slf4j</groupId>
-				</exclusion>
-				<exclusion>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>${mysql-connector-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
@@ -59,10 +44,6 @@
 			<artifactId>stream-applications-test-support</artifactId>
 			<version>${stream-apps-core.version}</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.kafka</groupId>
-			<artifactId>spring-kafka</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -102,27 +83,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>mysql</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mongodb</groupId>
-			<artifactId>mongodb-driver</artifactId>
-			<version>3.12.7</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mongodb</groupId>
-			<artifactId>bson</artifactId>
-			<version>3.12.7</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mongodb</groupId>
-			<artifactId>mongodb-driver-core</artifactId>
-			<version>3.12.7</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/applications/source/cdc-debezium-source/src/test/java/org/springframework/cloud/stream/app/source/cdc/CdcMySqlTestSupport.java
+++ b/applications/source/cdc-debezium-source/src/test/java/org/springframework/cloud/stream/app/source/cdc/CdcMySqlTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public abstract class CdcMySqlTestSupport {
 
 	static String MAPPED_PORT;
 
-	static GenericContainer debeziumMySQL = new GenericContainer<>("debezium/example-mysql:1.3")
+	static GenericContainer debeziumMySQL = new GenericContainer<>("debezium/example-mysql:1.7.1.Final")
 			.withEnv("MYSQL_ROOT_PASSWORD", "debezium")
 			.withEnv("MYSQL_USER", "mysqluser")
 			.withEnv("MYSQL_PASSWORD", "mysqlpw")

--- a/applications/source/cdc-debezium-source/src/test/java/org/springframework/cloud/stream/app/source/cdc/CdcSourceDatabasesIntegrationTest.java
+++ b/applications/source/cdc-debezium-source/src/test/java/org/springframework/cloud/stream/app/source/cdc/CdcSourceDatabasesIntegrationTest.java
@@ -52,7 +52,7 @@ public class CdcSourceDatabasesIntegrationTest {
 			TestChannelBinderConfiguration.getCompleteConfiguration(TestCdcSourceApplication.class))
 			.web(WebApplicationType.NONE)
 			.properties("spring.cloud.stream.function.definition=cdcSupplier",
-					"cdc.name=my-sql-connector",
+					"cdc.name=my-connector",
 					"cdc.flattening.dropTombstones=false",
 					"cdc.schema=false",
 					"cdc.flattening.enabled=true",
@@ -63,7 +63,7 @@ public class CdcSourceDatabasesIntegrationTest {
 
 	@Test
 	public void mysql() {
-		GenericContainer debeziumMySQL = new GenericContainer<>("debezium/example-mysql:1.3")
+		GenericContainer debeziumMySQL = new GenericContainer<>("debezium/example-mysql:1.7.1.Final")
 				.withEnv("MYSQL_ROOT_PASSWORD", "debezium")
 				.withEnv("MYSQL_USER", "mysqluser")
 				.withEnv("MYSQL_PASSWORD", "mysqlpw")
@@ -124,7 +124,7 @@ public class CdcSourceDatabasesIntegrationTest {
 
 	@Test
 	public void postgres() {
-		GenericContainer postgres = new GenericContainer("debezium/example-postgres:1.3")
+		GenericContainer postgres = new GenericContainer("debezium/example-postgres:1.7.1.Final")
 				.withEnv("POSTGRES_USER", "postgres")
 				.withEnv("POSTGRES_PASSWORD", "postgres")
 				.withExposedPorts(5432);
@@ -157,7 +157,7 @@ public class CdcSourceDatabasesIntegrationTest {
 	@Test
 	@Disabled
 	public void mongodb() {
-		GenericContainer mongodb = new GenericContainer("debezium/example-mongodb:1.3")
+		GenericContainer mongodb = new GenericContainer("debezium/example-mongodb:1.7.1.Final")
 				.withEnv("MONGODB_USER", "debezium")
 				.withEnv("MONGODB_PASSWORD", "dbz")
 				.withExposedPorts(27017);
@@ -169,7 +169,7 @@ public class CdcSourceDatabasesIntegrationTest {
 						"--cdc.config.mongodb.name=dbserver1",
 						"--cdc.config.mongodb.user=debezium",
 						"--cdc.config.mongodb.password=dbz",
-						"--cdc.config.database.whitelist=inventory")) {
+						"--cdc.config.collection.include.list=inventory[.]*")) {
 			OutputDestination outputDestination = context.getBean(OutputDestination.class);
 			// Using local region here
 			List<Message<?>> messages = receiveAll(outputDestination);

--- a/applications/source/cdc-debezium-source/src/test/resources/json/mysql_insert_inventory_products_106.json
+++ b/applications/source/cdc-debezium-source/src/test/resources/json/mysql_insert_inventory_products_106.json
@@ -22,7 +22,7 @@
     "thread": null,
     "query": null
   },
-  "op": "c",
+  "op": "r",
   "ts_ms": "${json-unit.ignore}",
   "transaction": null
 }

--- a/applications/source/mqtt-source/README.adoc
+++ b/applications/source/mqtt-source/README.adoc
@@ -24,6 +24,7 @@ $$keep-alive-interval$$:: $$the ping interval in seconds.$$ *($$Integer$$, defau
 $$password$$:: $$the password to use when connecting to the broker.$$ *($$String$$, default: `$$guest$$`)*
 $$persistence$$:: $$'memory' or 'file'.$$ *($$String$$, default: `$$memory$$`)*
 $$persistence-directory$$:: $$Persistence directory.$$ *($$String$$, default: `$$/tmp/paho$$`)*
+$$ssl-properties$$:: $$MQTT Client SSL properties.$$ *($$Map<String, String>$$, default: `$$<none>$$`)*
 $$url$$:: $$location of the mqtt broker(s) (comma-delimited list).$$ *($$String[]$$, default: `$$[tcp://localhost:1883]$$`)*
 $$username$$:: $$the username to use when connecting to the broker.$$ *($$String$$, default: `$$guest$$`)*
 

--- a/functions/common/cdc-debezium-boot-starter/pom.xml
+++ b/functions/common/cdc-debezium-boot-starter/pom.xml
@@ -15,7 +15,7 @@
 	<description>Change Data Capture (CDC) Debezium Boot Starter</description>
 
 	<properties>
-		<version.debezium>1.3.0.Final</version.debezium>
+		<version.debezium>1.7.1.Final</version.debezium>
 	</properties>
 
 	<dependencies>
@@ -38,24 +38,24 @@
 			<artifactId>debezium-connector-mysql</artifactId>
 			<exclusions>
 				<exclusion>
-					<artifactId>mysql-connector-java</artifactId>
-					<groupId>mysql</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+					<groupId>org.slf4j</groupId>
 				</exclusion>
 			</exclusions>
 			<version>${version.debezium}</version>
 		</dependency>
 
-		<!--		<dependency>-->
-		<!--			<groupId>io.debezium</groupId>-->
-		<!--			<artifactId>debezium-connector-mongodb</artifactId>-->
-		<!--			<exclusions>-->
-		<!--				<exclusion>-->
-		<!--					<artifactId>slf4j-log4j12</artifactId>-->
-		<!--					<groupId>org.slf4j</groupId>-->
-		<!--				</exclusion>-->
-		<!--			</exclusions>-->
-		<!--			<version>${version.debezium}</version>-->
-		<!--		</dependency>-->
+				<dependency>
+					<groupId>io.debezium</groupId>
+					<artifactId>debezium-connector-mongodb</artifactId>
+					<exclusions>
+						<exclusion>
+							<artifactId>slf4j-log4j12</artifactId>
+							<groupId>org.slf4j</groupId>
+						</exclusion>
+					</exclusions>
+					<version>${version.debezium}</version>
+				</dependency>
 
 		<dependency>
 			<groupId>io.debezium</groupId>
@@ -89,23 +89,6 @@
 				</exclusion>
 			</exclusions>
 			<version>${version.debezium}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.13</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>mysql</artifactId>
 		</dependency>
 
 		<dependency>

--- a/functions/common/cdc-debezium-boot-starter/src/test/java/org/springframework/cloud/fn/common/cdc/CdcBootStarterIntegrationTest.java
+++ b/functions/common/cdc-debezium-boot-starter/src/test/java/org/springframework/cloud/fn/common/cdc/CdcBootStarterIntegrationTest.java
@@ -50,7 +50,7 @@ public class CdcBootStarterIntegrationTest {
 
 	@Container
 	static GenericContainer debeziumMySQL =
-			new GenericContainer<>(DockerImageName.parse("debezium/example-mysql:1.3"))
+			new GenericContainer<>(DockerImageName.parse("debezium/example-mysql:1.7.1.Final"))
 					.withEnv("MYSQL_ROOT_PASSWORD", "debezium")
 					.withEnv("MYSQL_USER", "mysqluser")
 					.withEnv("MYSQL_PASSWORD", "mysqlpw")

--- a/functions/common/cdc-debezium-common/pom.xml
+++ b/functions/common/cdc-debezium-common/pom.xml
@@ -15,12 +15,7 @@
 	<description>Change Data Capture (CDC) Debezium Common</description>
 
 	<properties>
-		<version.debezium>1.3.1.Final</version.debezium>
-		<!-- Note: postgresql version MUST match the version used by the Debezium postgres connector -->
-		<postgresql.version>42.2.5</postgresql.version>
-		<spring-jdbc.version>5.2.1.RELEASE</spring-jdbc.version>
-		<!-- Debezium requires a particular mysql-connector version -->
-		<mysql-connector-java>5.1.46</mysql-connector-java>
+		<version.debezium>1.7.1.Final</version.debezium>
 	</properties>
 
 	<dependencies>
@@ -39,21 +34,8 @@
 		<dependency>
 			<groupId>io.debezium</groupId>
 			<artifactId>debezium-connector-mysql</artifactId>
-			<exclusions>
-				<exclusion>
-					<artifactId>mysql-connector-java</artifactId>
-					<groupId>mysql</groupId>
-				</exclusion>
-			</exclusions>
 			<optional>true</optional>
 			<version>${version.debezium}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<optional>true</optional>
-			<version>${mysql-connector-java}</version>
 		</dependency>
 
 		<dependency>
@@ -62,6 +44,7 @@
 			<optional>true</optional>
 			<version>${version.debezium}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>io.debezium</groupId>
 			<artifactId>debezium-connector-mongodb</artifactId>
@@ -87,16 +70,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-json</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-ip</artifactId>
@@ -105,17 +78,6 @@
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>config-common</artifactId>
 			<version>${revision}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/functions/consumer/mqtt-consumer/src/test/java/org/springframework/cloud/fn/consumer/mqtt/MqttConsumerTests.java
+++ b/functions/consumer/mqtt-consumer/src/test/java/org/springframework/cloud/fn/consumer/mqtt/MqttConsumerTests.java
@@ -35,7 +35,6 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
 import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
 import org.springframework.integration.mqtt.support.DefaultPahoMessageConverter;
-import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;

--- a/functions/supplier/cdc-debezium-supplier/pom.xml
+++ b/functions/supplier/cdc-debezium-supplier/pom.xml
@@ -14,8 +14,7 @@
     <description>CDC Debezium Suppliers</description>
 
     <properties>
-        <version.debezium>1.3.1.Final</version.debezium>
-        <mysql.version>8.0.13</mysql.version>
+        <version.debezium>1.7.1.Final</version.debezium>
     </properties>
 
     <dependencies>
@@ -25,24 +24,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql.version}</version>
-        </dependency>
-
-
-        <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-mysql</artifactId>
             <exclusions>
                 <exclusion>
-                    <artifactId>mysql-connector-java</artifactId>
-                    <groupId>mysql</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
                 </exclusion>
             </exclusions>
             <version>${version.debezium}</version>
         </dependency>
-
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-mongodb</artifactId>
@@ -87,38 +78,5 @@
             </exclusions>
             <version>${version.debezium}</version>
         </dependency>
-
-        <!-- -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/functions/supplier/mqtt-supplier/src/test/java/org/springframework/cloud/fn/supplier/mqtt/MqttSupplierTests.java
+++ b/functions/supplier/mqtt-supplier/src/test/java/org/springframework/cloud/fn/supplier/mqtt/MqttSupplierTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.fn.supplier.mqtt;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Properties;
 import java.util.function.Supplier;
 
@@ -27,6 +25,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -40,8 +40,7 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 
-import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for Mqtt Supplier.


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/182

* Upgrade Debezium dependency to 1.7.1
* Remove explicit dependencies for DBs and remove excludes for them from Debezium deps;
rely fully on whatever Debezium connectors bring for us
* Fix `EmbeddedEngine` for compatibility with the Debezium 1.7.1
* Fix CDC tests for the current state of Debezium results
* Fix Checkstyle violations in the MQTT modules