### PR TITLE
GH-207: Fix NPE in the HttpSupplierConfiguration

### DIFF
--- a/functions/supplier/http-supplier/README.adoc
+++ b/functions/supplier/http-supplier/README.adoc
@@ -24,6 +24,8 @@ All configuration properties are prefixed with `http`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/http/HttpSupplierProperties.java[HttpSupplierProperties].
 
+The `HeaderMapper<HttpHeaders>` bean can be provided in the target configuration to override a default one in the `HttpSupplierConfiguration`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/http/HttpSupplierApplicationTests.java[test suite] for the various ways, this supplier is used.

--- a/functions/supplier/http-supplier/src/main/java/org/springframework/cloud/fn/supplier/http/HttpSupplierConfiguration.java
+++ b/functions/supplier/http-supplier/src/main/java/org/springframework/cloud/fn/supplier/http/HttpSupplierConfiguration.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,34 +48,38 @@ import org.springframework.messaging.MessageHeaders;
 public class HttpSupplierConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean
+	public HeaderMapper<HttpHeaders> httpHeaderMapper(HttpSupplierProperties httpSupplierProperties) {
+		DefaultHttpHeaderMapper defaultHttpHeaderMapper = DefaultHttpHeaderMapper.inboundMapper();
+		defaultHttpHeaderMapper.setInboundHeaderNames(httpSupplierProperties.getMappedRequestHeaders());
+		return defaultHttpHeaderMapper;
+	}
+
+	@Bean
 	public Publisher<Message<byte[]>> httpSupplierFlow(HttpSupplierProperties httpSupplierProperties,
+			HeaderMapper<HttpHeaders> httpHeaderMapper,
 			ServerCodecConfigurer serverCodecConfigurer) {
 
 		return IntegrationFlows.from(
-				WebFlux.inboundChannelAdapter(httpSupplierProperties.getPathPattern())
-						.requestPayloadType(byte[].class)
-						.statusCodeExpression(new ValueExpression<>(HttpStatus.ACCEPTED))
-						.mappedRequestHeaders(httpSupplierProperties.getMappedRequestHeaders())
-						.codecConfigurer(serverCodecConfigurer)
-						.crossOrigin(crossOrigin ->
-								crossOrigin.origin(httpSupplierProperties.getCors().getAllowedOrigins())
-										.allowedHeaders(httpSupplierProperties.getCors().getAllowedHeaders())
-										.allowCredentials(httpSupplierProperties.getCors().getAllowCredentials()))
-						.autoStartup(false))
+						WebFlux.inboundChannelAdapter(httpSupplierProperties.getPathPattern())
+								.requestPayloadType(byte[].class)
+								.statusCodeExpression(new ValueExpression<>(HttpStatus.ACCEPTED))
+								.headerMapper(httpHeaderMapper)
+								.codecConfigurer(serverCodecConfigurer)
+								.crossOrigin(crossOrigin ->
+										crossOrigin.origin(httpSupplierProperties.getCors().getAllowedOrigins())
+												.allowedHeaders(httpSupplierProperties.getCors().getAllowedHeaders())
+												.allowCredentials(httpSupplierProperties.getCors().getAllowCredentials()))
+								.autoStartup(false))
 				.enrichHeaders((headers) ->
 						headers.headerFunction(MessageHeaders.CONTENT_TYPE,
 								(message) ->
-										(MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(
-												message.getHeaders().get(MessageHeaders.CONTENT_TYPE).toString()))
+										(MediaType.APPLICATION_FORM_URLENCODED.equals(
+												message.getHeaders().get(MessageHeaders.CONTENT_TYPE, MediaType.class)))
 												? MediaType.APPLICATION_JSON
 												: null,
 								true))
 				.toReactivePublisher();
-	}
-
-	@Bean
-	public HeaderMapper<HttpHeaders> httpHeaderMapper() {
-		return DefaultHttpHeaderMapper.inboundMapper();
 	}
 
 	@Bean


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/207

When no HTTP `Content-Type` header, the NPE is thrown from the `enrichHeaders()`
endpoint

* Fix NPE extracting header value via `get(MessageHeaders.CONTENT_TYPE, MediaType.class)`
* Make `httpHeaderMapper` bean as a `@ConditionalOnMissingBean` to let end-users
to provide their own custom `HeaderMapper<HttpHeaders>`
* Move `httpSupplierProperties.getMappedRequestHeaders()` setting to the `httpHeaderMapper` bean
* Use `httpHeaderMapper` bean injection into the `WebFlux.inboundChannelAdapter()` instead of
just `httpSupplierProperties.getMappedRequestHeaders()`
* Mention custom `HeaderMapper<HttpHeaders>` in the README