### PR TITLE
Change `doOnSubscribe` to `doOnRequest`

### DIFF
--- a/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionConfiguration.java
+++ b/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionConfiguration.java
@@ -63,7 +63,7 @@ public class AggregatorFunctionConfiguration {
 			FluxMessageChannel outputChannel) {
 
 		return input -> Flux.from(outputChannel)
-				.doOnSubscribe((sub) -> inputChannel.subscribeTo(input));
+				.doOnRequest((request) -> inputChannel.subscribeTo(input));
 	}
 
 	@Bean


### PR DESCRIPTION
The `aggregatorFunction` has a flaw subscribing and emitting
data from a source `Flux` too early: from a `doOnSubscribe()`
callback which is really called *before* the real subscription is
registered in the target `Publisher`

Change the logic to the `doOnRequest()` which happens already
after subscription is registered in the `Publisher`

**Cherry-pick to `2020.0.x`**