### PR TITLE
Re-enable and fix tests that were failing w/ Boot 2.6 upgrade.

### DIFF
--- a/applications/processor/script-processor/src/test/java/org/springframework/cloud/stream/app/processor/script/ScriptProcessorIntegrationTests.java
+++ b/applications/processor/script-processor/src/test/java/org/springframework/cloud/stream/app/processor/script/ScriptProcessorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.app.processor.script;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -44,7 +43,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Chris Schaefer
  * @author Soby Chacko
  */
-@Disabled
 public class ScriptProcessorIntegrationTests {
 
 	@Test

--- a/applications/sink/redis-sink/pom.xml
+++ b/applications/sink/redis-sink/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <properties>
-        <embedded-redis.version>2.0.9</embedded-redis.version>
+        <embedded-redis.version>2.0.11</embedded-redis.version>
     </properties>
 
     <dependencies>

--- a/applications/sink/redis-sink/pom.xml
+++ b/applications/sink/redis-sink/pom.xml
@@ -16,7 +16,6 @@
     </parent>
 
     <properties>
-        <spring-cloud-starters.version>3.0.3</spring-cloud-starters.version>
         <embedded-redis.version>2.0.9</embedded-redis.version>
     </properties>
 

--- a/applications/sink/redis-sink/src/test/java/org/springframework/cloud/stream/app/sink/redis/RedisSinkTests.java
+++ b/applications/sink/redis-sink/src/test/java/org/springframework/cloud/stream/app/sink/redis/RedisSinkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.app.sink.redis;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -42,7 +41,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Soby Chacko
  * @author Artem Bilan
  */
-@Disabled
 public class RedisSinkTests {
 
 	@Test

--- a/applications/sink/tcp-sink/src/test/java/org/springframework/cloud/stream/app/sink/tcp/TcpSinkTests.java
+++ b/applications/sink/tcp-sink/src/test/java/org/springframework/cloud/stream/app/sink/tcp/TcpSinkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -50,7 +49,6 @@ import org.springframework.messaging.Message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 public class TcpSinkTests {
 
 	private static TestTCPServer server;

--- a/applications/sink/websocket-sink/src/test/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkTests.java
+++ b/applications/sink/websocket-sink/src/test/java/org/springframework/cloud/stream/app/websocket/sink/WebsocketSinkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -49,7 +48,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 				"websocket.consumer.threads=2"
 		})
 @DirtiesContext
-@Disabled
 public class WebsocketSinkTests {
 
 	public static final int TIMEOUT = 10000;

--- a/applications/source/twitter-search-source/src/test/java/org/springframework/cloud/stream/app/source/twitter/search/TwitterSearchSourceIntegrationTests.java
+++ b/applications/source/twitter-search-source/src/test/java/org/springframework/cloud/stream/app/source/twitter/search/TwitterSearchSourceIntegrationTests.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;

--- a/applications/source/twitter-search-source/src/test/java/org/springframework/cloud/stream/app/source/twitter/search/TwitterSearchSourceIntegrationTests.java
+++ b/applications/source/twitter-search-source/src/test/java/org/springframework/cloud/stream/app/source/twitter/search/TwitterSearchSourceIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,6 @@ import static org.mockserver.verify.VerificationTimes.once;
 /**
  * @author Christian Tzolov
  */
-@Disabled
 public class TwitterSearchSourceIntegrationTests {
 
 	private static final String MOCK_SERVER_IP = "127.0.0.1";

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -31,7 +31,8 @@
         <!-- Boot 2.4.x needs wavefront-spring-boot version 2.1.0-RC1+ -->
         <wavefront-spring-boot.version>2.2.0</wavefront-spring-boot.version>
         <spring-cloud.version>2021.0.0</spring-cloud.version>
-    </properties>
+		<spring-cloud-starters.version>3.1.0</spring-cloud-starters.version>
+	</properties>
 
     <modules>
         <module>stream-applications-test-support</module>

--- a/functions/consumer/redis-consumer/pom.xml
+++ b/functions/consumer/redis-consumer/pom.xml
@@ -15,7 +15,6 @@
     <description>Redis Consumer</description>
 
     <properties>
-        <spring-cloud-starters.version>3.0.3</spring-cloud-starters.version>
         <embedded-redis.version>2.0.9</embedded-redis.version>
     </properties>
 

--- a/functions/consumer/redis-consumer/pom.xml
+++ b/functions/consumer/redis-consumer/pom.xml
@@ -15,7 +15,7 @@
     <description>Redis Consumer</description>
 
     <properties>
-        <embedded-redis.version>2.0.9</embedded-redis.version>
+        <embedded-redis.version>2.0.11</embedded-redis.version>
     </properties>
 
     <dependencies>

--- a/functions/consumer/tcp-consumer/src/main/java/org/springframework/cloud/fn/consumer/tcp/TcpConsumerConfiguration.java
+++ b/functions/consumer/tcp-consumer/src/main/java/org/springframework/cloud/fn/consumer/tcp/TcpConsumerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.cloud.fn.consumer.tcp;
 
 import java.util.function.Consumer;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.fn.common.tcp.EncoderDecoderFactoryBean;
@@ -38,28 +37,28 @@ import org.springframework.messaging.Message;
  *
  * @author Gary Russell
  * @author Christian Tzolov
+ * @author Chris Bono
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties({TcpConsumerProperties.class, TcpConnectionFactoryProperties.class})
 public class TcpConsumerConfiguration {
 
-	@Autowired
 	private TcpConsumerProperties properties;
-
-	@Autowired
 	private TcpConnectionFactoryProperties tcpConnectionProperties;
 
-	@Qualifier("tcpSinkConnectionFactory")
-	@Autowired
-	private AbstractConnectionFactory connectionFactory;
-
-	@Bean
-	public Consumer<Message<?>> tcpConsumer() {
-		return handler()::handleMessage;
+	public TcpConsumerConfiguration(TcpConsumerProperties properties,
+									TcpConnectionFactoryProperties tcpConnectionProperties) {
+		this.properties = properties;
+		this.tcpConnectionProperties = tcpConnectionProperties;
 	}
 
 	@Bean
-	public TcpSendingMessageHandlerSmartLifeCycle handler() {
+	public Consumer<Message<?>> tcpConsumer(TcpSendingMessageHandlerSmartLifeCycle handler) {
+		return handler::handleMessage;
+	}
+
+	@Bean
+	public TcpSendingMessageHandlerSmartLifeCycle handler(@Qualifier("tcpSinkConnectionFactory") AbstractConnectionFactory connectionFactory) {
 		TcpSendingMessageHandlerSmartLifeCycle tcpMessageHandler = new TcpSendingMessageHandlerSmartLifeCycle();
 		tcpMessageHandler.setConnectionFactory(connectionFactory);
 		return tcpMessageHandler;

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/CRLFTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/CRLFTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
@@ -25,7 +24,6 @@ import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer
 /**
  * @author Gary Russell
  */
-@Disabled
 public class CRLFTests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/L1Tests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/L1Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
@@ -25,8 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.encoder = L1" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.encoder = L1"})
 public class L1Tests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/L2Tests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/L2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
@@ -25,8 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.encoder = L2" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.encoder = L2"})
 public class L2Tests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/L4Tests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/L4Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
@@ -25,8 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.encoder = L4" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.encoder = L4"})
 public class L4Tests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/LFTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/LFTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLfSerializer;
@@ -25,8 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.encoder = LF" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.encoder = LF"})
 public class LFTests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/NULLTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/NULLTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.serializer.ByteArraySingleTerminatorSerializer;
@@ -25,8 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.encoder = NULL" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.encoder = NULL"})
 public class NULLTests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/NotNioTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/NotNioTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.connection.TcpNetClientConnectionFactory;
@@ -28,8 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.host = foo" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.host = foo"})
 public class NotNioTests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/PropertiesPopulatedTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/PropertiesPopulatedTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.connection.TcpNioClientConnectionFactory;
@@ -28,9 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.host = foo", "tcp.nio = true", "tcp.reverseLookup = true",
-		"tcp.useDirectBuffers = true", "tcp.socketTimeout = 123", "tcp.consumer.close = true", "tcp.consumer.charset = bar" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.host = foo", "tcp.nio = true", "tcp.reverseLookup = true",
+		"tcp.useDirectBuffers = true", "tcp.socketTimeout = 123", "tcp.consumer.close = true", "tcp.consumer.charset = bar"})
 public class PropertiesPopulatedTests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/RAWTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/RAWTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.ip.tcp.serializer.ByteArrayRawSerializer;
@@ -25,8 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * @author Gary Russell
  */
-@TestPropertySource(properties = { "tcp.consumer.encoder = RAW", "tcp.consumer.close = true" })
-@Disabled
+@TestPropertySource(properties = {"tcp.consumer.encoder = RAW", "tcp.consumer.close = true"})
 public class RAWTests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/STXETXTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/STXETXTests.java
@@ -16,9 +16,7 @@
 
 package org.springframework.cloud.fn.consumer.tcp;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.integration.ip.tcp.serializer.ByteArrayStxEtxSerializer;
 import org.springframework.test.context.TestPropertySource;
 
@@ -26,7 +24,6 @@ import org.springframework.test.context.TestPropertySource;
  * @author Gary Russell
  */
 @TestPropertySource(properties = { "tcp.consumer.encoder = STXETX" })
-@Disabled
 public class STXETXTests extends AbstractTcpConsumerTests {
 
 	@Test

--- a/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/STXETXTests.java
+++ b/functions/consumer/tcp-consumer/src/test/java/org/springframework/cloud/fn/consumer/tcp/STXETXTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.fn.consumer.tcp;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.integration.ip.tcp.serializer.ByteArrayStxEtxSerializer;
 import org.springframework.test.context.TestPropertySource;
 

--- a/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerConfiguration.java
+++ b/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerConfiguration.java
@@ -62,24 +62,6 @@ public class WebsocketConsumerConfiguration {
 		websocketConsumerServer.run();
 	}
 
-	@Configuration
-	static class WebsocketConsumerServerConfiguration {
-		@Bean
-		public InMemoryTraceRepository websocketTraceRepository() {
-			return new InMemoryTraceRepository();
-		}
-
-		@Bean
-		public WebsocketConsumerServer server(WebsocketConsumerProperties properties, WebsocketConsumerServerInitializer initializer) {
-			return new WebsocketConsumerServer(properties, initializer);
-		}
-
-		@Bean
-		public WebsocketConsumerServerInitializer initializer(InMemoryTraceRepository websocketTraceRepository) {
-			return new WebsocketConsumerServerInitializer(websocketTraceRepository);
-		}
-	}
-
 	@Bean
 	@ConditionalOnProperty(value = "endpoints.websocketsinktrace.enabled", havingValue = "true")
 	public WebsocketConsumerTraceEndpoint websocketTraceEndpoint(InMemoryTraceRepository websocketTraceRepository) {
@@ -118,4 +100,23 @@ public class WebsocketConsumerConfiguration {
 		trace.put("payload", message.getPayload().toString());
 		websocketTraceRepository.add(trace);
 	}
+
+	@Configuration
+	static class WebsocketConsumerServerConfiguration {
+		@Bean
+		public InMemoryTraceRepository websocketTraceRepository() {
+			return new InMemoryTraceRepository();
+		}
+
+		@Bean
+		public WebsocketConsumerServer server(WebsocketConsumerProperties properties, WebsocketConsumerServerInitializer initializer) {
+			return new WebsocketConsumerServer(properties, initializer);
+		}
+
+		@Bean
+		public WebsocketConsumerServerInitializer initializer(InMemoryTraceRepository websocketTraceRepository) {
+			return new WebsocketConsumerServerInitializer(websocketTraceRepository);
+		}
+	}
+
 }

--- a/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerConfiguration.java
+++ b/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -42,42 +43,51 @@ import org.springframework.messaging.simp.SimpMessageType;
  * @author Oliver Moser
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Chris Bono
  */
 @Configuration
 @EnableConfigurationProperties(WebsocketConsumerProperties.class)
 public class WebsocketConsumerConfiguration {
 
-
 	private static final Log logger = LogFactory.getLog(WebsocketConsumerConfiguration.class);
-
-	private final InMemoryTraceRepository websocketTraceRepository = new InMemoryTraceRepository();
 
 	@Value("${endpoints.websocketconsumertrace.enabled:false}")
 	private boolean traceEndpointEnabled;
 
+	@Autowired
+	private WebsocketConsumerServer websocketConsumerServer;
+
 	@PostConstruct
 	public void init() throws InterruptedException {
-		server().run();
+		websocketConsumerServer.run();
 	}
 
-	@Bean
-	public WebsocketConsumerServer server() {
-		return new WebsocketConsumerServer();
-	}
+	@Configuration
+	static class WebsocketConsumerServerConfiguration {
+		@Bean
+		public InMemoryTraceRepository websocketTraceRepository() {
+			return new InMemoryTraceRepository();
+		}
 
-	@Bean
-	public WebsocketConsumerServerInitializer initializer() {
-		return new WebsocketConsumerServerInitializer(this.websocketTraceRepository);
+		@Bean
+		public WebsocketConsumerServer server(WebsocketConsumerProperties properties, WebsocketConsumerServerInitializer initializer) {
+			return new WebsocketConsumerServer(properties, initializer);
+		}
+
+		@Bean
+		public WebsocketConsumerServerInitializer initializer(InMemoryTraceRepository websocketTraceRepository) {
+			return new WebsocketConsumerServerInitializer(websocketTraceRepository);
+		}
 	}
 
 	@Bean
 	@ConditionalOnProperty(value = "endpoints.websocketsinktrace.enabled", havingValue = "true")
-	public WebsocketConsumerTraceEndpoint websocketTraceEndpoint() {
-		return new WebsocketConsumerTraceEndpoint(this.websocketTraceRepository);
+	public WebsocketConsumerTraceEndpoint websocketTraceEndpoint(InMemoryTraceRepository websocketTraceRepository) {
+		return new WebsocketConsumerTraceEndpoint(websocketTraceRepository);
 	}
 
 	@Bean
-	public Consumer<Message<?>> websocketConsumer() {
+	public Consumer<Message<?>> websocketConsumer(InMemoryTraceRepository websocketTraceRepository) {
 		return message -> {
 			if (logger.isTraceEnabled()) {
 				logger.trace("Handling message: " + message);
@@ -95,17 +105,17 @@ public class WebsocketConsumerConfiguration {
 			}
 
 			if (this.traceEndpointEnabled) {
-				addMessageToTraceRepository(message);
+				addMessageToTraceRepository(websocketTraceRepository, message);
 			}
 		};
 	}
 
-	private void addMessageToTraceRepository(Message<?> message) {
+	private void addMessageToTraceRepository(InMemoryTraceRepository websocketTraceRepository, Message<?> message) {
 		Map<String, Object> trace = new LinkedHashMap<>();
 		trace.put("type", "text");
 		trace.put("direction", "out");
 		trace.put("id", message.getHeaders().getId());
 		trace.put("payload", message.getPayload().toString());
-		this.websocketTraceRepository.add(trace);
+		websocketTraceRepository.add(trace);
 	}
 }

--- a/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerServer.java
+++ b/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerServer.java
@@ -58,7 +58,7 @@ public class WebsocketConsumerServer {
 
 	private int port;
 
-	WebsocketConsumerServer(WebsocketConsumerProperties properties, WebsocketConsumerServerInitializer initializer) {
+	public WebsocketConsumerServer(WebsocketConsumerProperties properties, WebsocketConsumerServerInitializer initializer) {
 		this.properties = properties;
 		this.initializer = initializer;
 	}

--- a/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerServer.java
+++ b/functions/consumer/websocket-consumer/src/main/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,6 @@ import io.netty.handler.logging.LoggingHandler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 /**
  * Bootstraps a Netty server using the {@link WebsocketConsumerServerInitializer}. Also adds
  * a {@link LoggingHandler} and uses the <code>logLevel</code>
@@ -42,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author Oliver Moser
  * @author Gary Russell
+ * @author Chris Bono
  */
 public class WebsocketConsumerServer {
 
@@ -49,17 +48,20 @@ public class WebsocketConsumerServer {
 
 	static final List<Channel> channels = Collections.synchronizedList(new ArrayList<Channel>());
 
-	@Autowired
-	WebsocketConsumerProperties properties;
+	private WebsocketConsumerProperties properties;
 
-	@Autowired
-	WebsocketConsumerServerInitializer initializer;
+	private WebsocketConsumerServerInitializer initializer;
 
 	private EventLoopGroup bossGroup;
 
 	private EventLoopGroup workerGroup;
 
 	private int port;
+
+	WebsocketConsumerServer(WebsocketConsumerProperties properties, WebsocketConsumerServerInitializer initializer) {
+		this.properties = properties;
+		this.initializer = initializer;
+	}
 
 	public int getPort() {
 		return this.port;

--- a/functions/consumer/websocket-consumer/src/test/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerTests.java
+++ b/functions/consumer/websocket-consumer/src/test/java/org/springframework/cloud/fn/consumer/websocket/WebsocketConsumerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -51,7 +50,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 				"websocket.consumer.threads=2"
 		})
 @DirtiesContext
-@Disabled
 public class WebsocketConsumerTests {
 
 	public static final int TIMEOUT = 10000;

--- a/functions/supplier/mongodb-supplier/src/test/java/org/springframework/cloud/fn/supplier/mongo/MongodbSupplierApplicationTests.java
+++ b/functions/supplier/mongodb-supplier/src/test/java/org/springframework/cloud/fn/supplier/mongo/MongodbSupplierApplicationTests.java
@@ -26,7 +26,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;

--- a/functions/supplier/twitter-supplier/src/main/java/org/springframework/cloud/fn/supplier/twitter/status/search/TwitterSearchSupplierConfiguration.java
+++ b/functions/supplier/twitter-supplier/src/main/java/org/springframework/cloud/fn/supplier/twitter/status/search/TwitterSearchSupplierConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,8 @@ import org.springframework.util.StringUtils;
  * Search pagination with max_id and since_id: https://developer.twitter.com/en/docs/tweets/timelines/guides/working-with-timelines.html .
  *
  * @author Christian Tzolov
+ * @author Chris Bono
  */
-
 @EnableConfigurationProperties({ TwitterSearchSupplierProperties.class })
 @Import(TwitterConnectionConfiguration.class)
 public class TwitterSearchSupplierConfiguration {
@@ -57,9 +57,6 @@ public class TwitterSearchSupplierConfiguration {
 	private Twitter twitter;
 
 	@Autowired
-	private SearchPagination searchPage;
-
-	@Autowired
 	private Function<Object, Message<byte[]>> json;
 
 	@Bean
@@ -71,18 +68,18 @@ public class TwitterSearchSupplierConfiguration {
 
 
 	@Bean
-	public Supplier<Message<byte[]>> twitterSearchSupplier() {
+	public Supplier<Message<byte[]>> twitterSearchSupplier(SearchPagination searchPage) {
 		return () -> {
 			try {
-				Query query = toQuery(this.searchProperties, this.searchPage);
+				Query query = toQuery(this.searchProperties, searchPage);
 
 				QueryResult result = this.twitter.search(query);
 
 				List<Status> tweets = result.getTweets();
 
-				logger.info(String.format("%s, size: %s", this.searchPage.status(), tweets.size()));
+				logger.info(String.format("%s, size: %s", searchPage.status(), tweets.size()));
 
-				this.searchPage.update(tweets);
+				searchPage.update(tweets);
 
 				return this.json.apply(tweets);
 			}

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -46,7 +46,7 @@
 		<spring-cloud-function.version>3.2.1</spring-cloud-function.version>
 		<spring-cloud-starters.version>3.1.0</spring-cloud-starters.version>
 		<spring-data-geode-test.version>0.0.21.RELEASE</spring-data-geode-test.version>
-		<test-containers.version>1.15.3</test-containers.version>
+		<test-containers.version>1.16.3</test-containers.version>
 		<maven-flatten-plugin.version>1.2.5</maven-flatten-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 	</properties>

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -44,8 +44,9 @@
 		<spring-kafka.version>2.8.2</spring-kafka.version>
 		<spring-rabbit.version>2.4.2</spring-rabbit.version>
 		<spring-cloud-function.version>3.2.1</spring-cloud-function.version>
+		<spring-cloud-starters.version>3.1.0</spring-cloud-starters.version>
 		<spring-data-geode-test.version>0.0.21.RELEASE</spring-data-geode-test.version>
-		<test-containers.version>1.15.2</test-containers.version>
+		<test-containers.version>1.15.3</test-containers.version>
 		<maven-flatten-plugin.version>1.2.5</maven-flatten-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 	</properties>
@@ -322,8 +323,8 @@
 			<build>
 				<plugins>
 					<plugin>
-						 <groupId>org.apache.maven.plugins</groupId>
-						 <artifactId>maven-surefire-plugin</artifactId>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
 						<configuration>
 							<excludedGroups>integration</excludedGroups>
 						</configuration>


### PR DESCRIPTION
I will comment inline where appropriate. 

This fixes all previously disabled tests except the security ones which are being handled in @dturanski [code proposal](https://github.com/spring-cloud/stream-applications/pull/212).

Also, @artembilan I went ahead and kept the MongoDB tests in this PR. If you are ok w/ that we can close https://github.com/spring-cloud/stream-applications/pull/211.

