### PR TITLE
Add requiresUnpack for script-processor

### DIFF
--- a/applications/processor/script-processor/pom.xml
+++ b/applications/processor/script-processor/pom.xml
@@ -121,6 +121,18 @@
                                 </dependency>
                             </dependencies>
                         </maven>
+
+                        <bootPluginConfiguration>
+                            <![CDATA[
+                                        <requiresUnpack>
+                                            <dependency>
+                                                <groupId>org.python</groupId>
+                                                <artifactId>jython-standalone</artifactId>
+                                            </dependency>
+                                        </requiresUnpack>
+                                        ]]>
+                        </bootPluginConfiguration>
+
                     </application>
                 </configuration>
             </plugin>

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -23,7 +23,7 @@
         <mockserver.version>5.10</mockserver.version>
         <spring-cloud-stream-dependencies.version>3.2.1</spring-cloud-stream-dependencies.version>
         <spring-cloud-stream.version>3.2.1</spring-cloud-stream.version>
-        <spring-cloud-dataflow-apps-generator-plugin.version>1.0.5</spring-cloud-dataflow-apps-generator-plugin.version>
+        <spring-cloud-dataflow-apps-generator-plugin.version>1.0.6-SNAPSHOT</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.5</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.5</spring-cloud-dataflow-apps-metadata-plugin.version>
         <java-cfenv-boot.version>2.1.2.RELEASE</java-cfenv-boot.version>


### PR DESCRIPTION
The `Jython` doesn't work in the uber jar as a nested one.
The Spring Boot provides a trick via unpacking requested nested jars.

* Use the latest `spring-cloud-dataflow-apps-generator-plugin` which allows now
to propagate a custom configuration for `spring-boot-maven-plugin`
* Add `requiresUnpack` for `jython-standalone` into the `script-processor`

**Cherry-pick to 2021.1.x**