### PR TITLE
Set spring.integration.jdbc.platform in jdbc-sink app

### DIFF
--- a/applications/source/jdbc-source/src/main/resources/application.properties
+++ b/applications/source/jdbc-source/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.integration.jdbc.platform=mysql

--- a/applications/source/jdbc-source/src/main/resources/application.properties
+++ b/applications/source/jdbc-source/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.integration.jdbc.platform=mysql


### PR DESCRIPTION
Fixes IT failure KafkaJdbcLogStreamTests

The `jdbc-source-kafka` is failing to properly start. It is attempting to determine the DB platform type from an actual connection but the DB is not yet up. This is due to the rework of DB init scripts in 2.6 ([bug outlined here](https://github.com/spring-projects/spring-boot/issues/28897)).

~This sets `spring.integration.jdbc.platform=mysql` to specify the platform.~

This now uses `@Nested` to wait for the outer `@Container` to start.


