### PR TITLE
Make docker image tags and IT usage of those tags more explicit

### DIFF
--- a/src/main/groovy/org/springframework/jenkins/stream/applications/ci/StreamApplicationsBuildMaker.groovy
+++ b/src/main/groovy/org/springframework/jenkins/stream/applications/ci/StreamApplicationsBuildMaker.groovy
@@ -181,11 +181,11 @@ class StreamApplicationsBuildMaker implements JdkConfig, TestPublisher,
                     cd applications/${cdToApps}
                     cd apps
                     set +x
-                    ./mvnw -U clean package jib:build -DskipTests -Djib.httpTimeout=1800000 -Djib.to.auth.username="\$${dockerHubUserNameEnvVar()}" -Djib.to.auth.password="\$${dockerHubPasswordEnvVar()}"
+                    ./mvnw -U clean package jib:build -DskipTests -Djib.to.tags=${branchToBuild} -Djib.httpTimeout=1800000 -Djib.to.auth.username="\$${dockerHubUserNameEnvVar()}" -Djib.to.auth.password="\$${dockerHubPasswordEnvVar()}"
 					if [[ "\$?" -ne 0 ]] ; then
                             set -e
                             echo "Apps Docker Build failed: Rerunning again"
-                            ./mvnw -U clean package jib:build -DskipTests -Djib.httpTimeout=1800000 -Djib.to.auth.username="\$${dockerHubUserNameEnvVar()}" -Djib.to.auth.password="\$${dockerHubPasswordEnvVar()}"
+                            ./mvnw -U clean package jib:build -DskipTests -Djib.to.tags=${branchToBuild} -Djib.httpTimeout=1800000 -Djib.to.auth.username="\$${dockerHubUserNameEnvVar()}" -Djib.to.auth.password="\$${dockerHubPasswordEnvVar()}"
                         fi
 					set -x
 					${cleanGitCredentials()}
@@ -194,7 +194,7 @@ class StreamApplicationsBuildMaker implements JdkConfig, TestPublisher,
                 if (integTestsBuild) {
                     maven {
                         mavenInstallation(maven35())
-                        goals('-U clean test -pl :stream-applications-integration-tests -Pintegration -Dspring.cloud.stream.applications.version=latest')
+                        goals("-U clean test -pl :stream-applications-integration-tests -Pintegration -Dspring.cloud.stream.applications.version=${branchToBuild}")
                     }
                 }
             }


### PR DESCRIPTION
* Add branch tag to docker image for all builds
* Add 'latest' tag to docker image for main branch build
* Run ITs against specific branch docker image

This coupled w/ the changes in 

- https://github.com/spring-cloud/spring-cloud-dataflow-apps-plugin/pull/12 
- https://github.com/spring-cloud/stream-applications/pull/230

should make things work smoothly.