### PR TITLE
Add functionDefinition=loadGeneratorSupplier

### DIFF
--- a/applications/source/load-generator-source/pom.xml
+++ b/applications/source/load-generator-source/pom.xml
@@ -21,11 +21,6 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -40,6 +35,7 @@
                 <configuration>
                     <application>
                         <name>load-generator</name>
+                        <functionDefinition>loadGeneratorSupplier</functionDefinition>
                         <type>source</type>
                         <version>${project.version}</version>
                         <configClass>


### PR DESCRIPTION
The `load-generator-source` does not generate a proper name for the function bean.
Use an explicit `<functionDefinition>loadGeneratorSupplier</functionDefinition>`
since the `<name>load-generator</name>` is not cameCase-compatible with
existing `loadGeneratorSupplier` bean name

**Cherry-pick to `2021.1.x`**