### PR TITLE
Fix auto-import of Kafka apps in SCDF

### DIFF
--- a/stream-applications-release-train/stream-applications-descriptor/src/main/resources/META-INF/kafka-apps-maven.properties
+++ b/stream-applications-release-train/stream-applications-descriptor/src/main/resources/META-INF/kafka-apps-maven.properties
@@ -1,5 +1,5 @@
 source.cdc-debezium=maven://org.springframework.cloud.stream.app:cdc-debezium-source-kafka:@apps.version@
-source.cdc-debezium.metadata=maven://org.springframework.cloud.stream.app:cdc-debezium-source-kafka:jar:metadata::@apps.version@
+source.cdc-debezium.metadata=maven://org.springframework.cloud.stream.app:cdc-debezium-source-kafka:jar:metadata:@apps.version@
 source.file=maven://org.springframework.cloud.stream.app:file-source-kafka:@apps.version@
 source.file.metadata=maven://org.springframework.cloud.stream.app:file-source-kafka:jar:metadata:@apps.version@
 source.ftp=maven://org.springframework.cloud.stream.app:ftp-source-kafka:@apps.version@
@@ -18,7 +18,7 @@ source.mail=maven://org.springframework.cloud.stream.app:mail-source-kafka:@apps
 source.mail.metadata=maven://org.springframework.cloud.stream.app:mail-source-kafka:jar:metadata:@apps.version@
 source.mongodb=maven://org.springframework.cloud.stream.app:mongodb-source-kafka:@apps.version@
 source.mongodb.metadata=maven://org.springframework.cloud.stream.app:mongodb-source-kafka:jar:metadata:@apps.version@
-source.mqtt=maven://org.springframework.cloud.stream.app:mqtt-source-kafkaapps.version@
+source.mqtt=maven://org.springframework.cloud.stream.app:mqtt-source-kafka:@apps.version@
 source.mqtt.metadata=maven://org.springframework.cloud.stream.app:mqtt-source-kafka:jar:metadata:@apps.version@
 source.rabbit=maven://org.springframework.cloud.stream.app:rabbit-source-kafka:@apps.version@
 source.rabbit.metadata=maven://org.springframework.cloud.stream.app:rabbit-source-kafka:jar:metadata:@apps.version@


### PR DESCRIPTION
Fixes the following:

The following error is thrown when SCDF attempts to auto-import the Kafka apps. 
```
dataflow-server             | java.lang.IllegalArgumentException: Bad artifact coordinates org.springframework.cloud.stream.app:cdc-debezium-source-kafka:jar:metadata::3.2.0, expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
dataflow-server             | 	at org.springframework.util.Assert.isTrue(Assert.java:121)
[11:42](https://vmware.slack.com/archives/D02UXPU2EJV/p1646415744809939)
```

Steps to reproduce:
```
wget -O docker-compose.yml https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/v2.10.0-M1/src/docker-compose/docker-compose.yml

DATAFLOW_VERSION=2.10.0-M1 SKIPPER_VERSION=2.9.0-M1 docker-compose up
```