### PR TITLE
GH-248: Exclude Geode SSL config

### DIFF
--- a/applications/processor/aggregator-processor/src/test/java/org/springframework/cloud/fn/aggregator/AggregatorProcessorTests.java
+++ b/applications/processor/aggregator-processor/src/test/java/org/springframework/cloud/fn/aggregator/AggregatorProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AggregatorProcessorTests {
 
 	@Test
-	public void testFilterProcessor() {
+	public void testWithJdbcMessageStore() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 				TestChannelBinderConfiguration.getCompleteConfiguration(AggregatorProcessorTestApplication.class))
 				.web(WebApplicationType.NONE)

--- a/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
+++ b/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/ExcludeStoresAutoConfigurationEnvironmentPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.geode.boot.autoconfigure.ClientCacheAutoConfiguration;
+import org.springframework.geode.boot.autoconfigure.SslAutoConfiguration;
 
 /**
  * An {@link EnvironmentPostProcessor} to add {@code spring.autoconfigure.exclude} property
@@ -56,6 +57,12 @@ public class ExcludeStoresAutoConfigurationEnvironmentPostProcessor implements E
 						ClientCacheAutoConfiguration.class.getName() + ", " +
 						RedisAutoConfiguration.class.getName() + ", " +
 						RedisRepositoriesAutoConfiguration.class.getName());
+
+		String messageStoreType = environment.getProperty(AggregatorFunctionProperties.PREFIX + ".message-store-type");
+		if (!AggregatorFunctionProperties.MessageStoreType.GEMFIRE.equals(messageStoreType)) {
+			properties.setProperty(SslAutoConfiguration.SECURITY_SSL_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY,
+					"false");
+		}
 
 		propertySources.addLast(
 				new PropertiesPropertySource("aggregator.exclude.stores.auto-configuration", properties));

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/AbstractAggregatorFunctionTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/AbstractAggregatorFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import java.util.function.Function;
 import reactor.core.publisher.Flux;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.geode.boot.autoconfigure.SslAutoConfiguration;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.messaging.Message;
@@ -43,6 +45,9 @@ public abstract class AbstractAggregatorFunctionTests {
 
 	@Autowired
 	protected AggregatingMessageHandler aggregatingMessageHandler;
+
+	@Value("${" + SslAutoConfiguration.SECURITY_SSL_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY + ":true}")
+	protected Boolean geodeSslEnable;
 
 	@SpringBootApplication
 	static class AggregatorFunctionTestApplication {

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,8 @@ public class DefaultAggregatorTests extends AbstractAggregatorFunctionTests {
 
 		assertThat(this.messageGroupStore).isNull();
 		assertThat(this.aggregatingMessageHandler.getMessageStore()).isInstanceOf(SimpleMessageStore.class);
+
+		assertThat(this.geodeSslEnable).isFalse();
 	}
 
 }

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/GroupTimeOutAndGemfireMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/GroupTimeOutAndGemfireMessageStoreAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,8 @@ public class GroupTimeOutAndGemfireMessageStoreAggregatorTests extends AbstractA
 
 		assertThat(this.messageGroupStore).isInstanceOf(GemfireMessageStore.class);
 		assertThat(this.aggregatingMessageHandler.getMessageStore()).isSameAs(this.messageGroupStore);
+
+		assertThat(this.geodeSslEnable).isTrue();
 	}
 
 }

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,8 @@ public class JdbcMessageStoreAggregatorTests extends AbstractAggregatorFunctionT
 		assertThat(this.messageGroupStore).isInstanceOf(JdbcMessageStore.class);
 
 		assertThat(this.aggregatingMessageHandler.getMessageStore()).isSameAs(this.messageGroupStore);
+
+		assertThat(this.geodeSslEnable).isFalse();
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/248

The Geode SSL auto-config is done via `SslAutoConfiguration.SslEnvironmentPostProcessor`
which cannot be excluded as an auto-config.

* Set `SslAutoConfiguration.SECURITY_SSL_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY`
to `false` from the `ExcludeStoresAutoConfigurationEnvironmentPostProcessor`
when the store type is not Geode