### PR TITLE
GH-249: Add metadata-store to file-supplier

### DIFF
--- a/applications/source/file-source/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
+++ b/applications/source/file-source/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
@@ -1,2 +1,10 @@
 configuration-properties.classes=org.springframework.cloud.fn.supplier.file.FileSupplierProperties,\
-  org.springframework.cloud.fn.common.file.FileConsumerProperties
+  org.springframework.cloud.fn.common.file.FileConsumerProperties, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Gemfire, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Redis, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$DynamoDb, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Jdbc, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Zookeeper, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Mongo
+

--- a/applications/source/file-source/src/main/resources/META-INF/dataflow-configuration-metadata.properties
+++ b/applications/source/file-source/src/main/resources/META-INF/dataflow-configuration-metadata.properties
@@ -1,2 +1,10 @@
 configuration-properties.classes=org.springframework.cloud.fn.supplier.file.FileSupplierProperties,\
-  org.springframework.cloud.fn.common.file.FileConsumerProperties
+  org.springframework.cloud.fn.common.file.FileConsumerProperties, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Gemfire, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Redis, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$DynamoDb, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Jdbc, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Zookeeper, \
+  org.springframework.cloud.fn.common.metadata.store.MetadataStoreProperties$Mongo
+

--- a/functions/supplier/file-supplier/pom.xml
+++ b/functions/supplier/file-supplier/pom.xml
@@ -19,36 +19,29 @@
             <artifactId>spring-integration-file</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-integration</artifactId>
+            <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>metadata-store-common</artifactId>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>file-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-json</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/functions/supplier/s3-supplier/README.adoc
+++ b/functions/supplier/s3-supplier/README.adoc
@@ -23,7 +23,7 @@ Once injected, you can use the `get` method of the `Supplier` to invoke it and t
 All configuration properties are prefixed with `s3.supplier`.
 There are also properties that need to be used with the prefix `s3.common` and `file.consumer`.
 
-For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/s3/AwsS3SupplierProperties.java[AwsS3upplierProperties],
+For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/s3/AwsS3SupplierProperties.java[AwsS3SupplierProperties],
 link:../../common/file-common/src/main/java/org/springframework/cloud/fn/common/file/FileConsumerProperties.java[FileConsumerProperties], and
 link:../../common/aws-s3-common/src/main/java/org/springframework/cloud/fn/common/aws/s3/AmazonS3Properties.java[AmazonS3Properties].
 


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/249

Currently, the metadata store is supported by remote files source (S3, ftp and sftp), but not by file source.
There are cases where it is convenient to be able to use the metadata store with file source as well.

* Add externally configured `ConcurrentMetadataStore` into `FileSupplierConfiguration`
which is based on the auto-configuration provided by the `metadata-store-common` artifact
* Test with an embedded JDBC store
* Remove redundant dependencies in the file-supplier pom - supplied by the parent
* Add `MetadataStoreProperties` to allow-list for dataflow
* Fix typo in the `s3-supplier` README