### PR TITLE
Fix circular dependency and checkstyle in config-common

### DIFF
--- a/functions/common/config-common/pom.xml
+++ b/functions/common/config-common/pom.xml
@@ -4,9 +4,9 @@
 
     <parent>
         <groupId>org.springframework.cloud.fn</groupId>
-        <artifactId>spring-functions-parent</artifactId>
+        <artifactId>java-functions-parent</artifactId>
         <version>${revision}</version>
-        <relativePath>../../spring-functions-parent</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>config-common</artifactId>

--- a/functions/common/config-common/src/main/java/org/springframework/cloud/fn/common/config/ComponentCustomizationAutoConfiguration.java
+++ b/functions/common/config-common/src/main/java/org/springframework/cloud/fn/common/config/ComponentCustomizationAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.fn.common.config;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * An auto-configuration to expose customizer strategy beans to accept user-provided component customizers.
@@ -29,6 +30,8 @@ import org.springframework.context.annotation.Bean;
  *
  * @see ComponentCustomizerBeanPostProcessor
  */
+// @checkstyle:off HideUtilityClassConstructor
+@Configuration(proxyBeanMethods = false)
 public class ComponentCustomizationAutoConfiguration {
 
 	@Bean
@@ -36,5 +39,5 @@ public class ComponentCustomizationAutoConfiguration {
 	static BeanPostProcessor componentCustomizerBeanPostProcessor() {
 		return new ComponentCustomizerBeanPostProcessor();
 	}
-
 }
+// @checkstyle:on


### PR DESCRIPTION
### Problem 1
The [CI build was failing](https://jenkins.spring.io/job/stream-applications-java-functions-main-ci/805/console) w/ 
```java
Downloaded from spring-releases: https://repo.spring.io/release/org/springframework/security/spring-security-bom/5.6.5/spring-security-bom-5.6.5.pom (5.7 kB at 11 kB/s)
Downloading from tensorflow-snapshots: https://oss.sonatype.org/content/repositories/snapshots/org/springframework/cloud/stream/app/stream-applications-build/1.2.1-SNAPSHOT/maven-metadata.xml
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] 'dependencies.dependency. org.springframework.cloud.fn:config-common:1.2.1-SNAPSHOT' for org.springframework.cloud.fn:config-common:1.2.1-SNAPSHOT is referencing itself. @ org.springframework.cloud.fn:spring-functions-parent:[unknown-version], /opt/jenkins/data/workspace/stream-applications-java-functions-main-ci/functions/spring-functions-parent/pom.xml, line 22, column 15
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.springframework.cloud.fn:config-common:1.2.1-SNAPSHOT (/opt/jenkins/data/workspace/stream-applications-java-functions-main-ci/functions/common/config-common/pom.xml) has 1 error
[ERROR]     'dependencies.dependency. org.springframework.cloud.fn:config-common:1.2.1-SNAPSHOT' for org.springframework.cloud.fn:config-common:1.2.1-SNAPSHOT is referencing itself. @ org.springframework.cloud.fn:spring-functions-parent:[unknown-version], /opt/jenkins/data/workspace/stream-applications-java-functions-main-ci/functions/spring-functions-parent/pom.xml, line 22, column 15
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
```

The reason is that `spring-functions-parent` includes `config-common` but `config-common` lists `spring-function-parent` as its parent. The solution is to move `config-common` parent to `java-functions-parent`. 

### Problem 2
After that was fixed we then ran into a checkstyle around "HideUtilityClassConstructor" 
```java
[INFO] --- maven-checkstyle-plugin:3.1.0:check (checkstyle-validation) @ config-common ---
[INFO] Starting audit...
[ERROR] /Users/cbono/repos/stream-applications/functions/common/config-common/src/main/java/org/springframework/cloud/fn/common/config/ComponentCustomizationAutoConfiguration.java:33:1: Utility classes should not have a public or default constructor. [HideUtilityClassConstructor]
Audit done.
```
Solution is to disable specific checkstyle on auto-config. 

Also note that I added `@Configuration` to `ComponentCustomizationAutoConfiguration` as it was not there before. Although its not technically required I think for consistency we should add it. 