### PR TITLE
[DO_NOT_MERGE] - Only to show already committed changes

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,4 +5,7 @@
         <artifactId>project-settings-extension</artifactId>
         <version>0.2.3</version>
     </extension>
+
+    <!-- BONO: Added this to "add" the project settings.xml to the existing settings.xml \ -->
+
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,3 @@
 -DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local -P spring,spring-repos
+
+// BONO: Added the spring-repos as the extension replaces the profiles, but we want them to merge the content so we rename

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <profiles>
+
+        <!-- BONO: These are the default Spring repos we want the wrapper to use -->
+
         <profile>
             <id>spring-repos</id>
             <activation>

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -311,4 +311,6 @@
         </pluginManagement>
     </build>
 
+    <!-- BONO: Removed the <repositories/pluginRepositories> -->
+
 </project>

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -94,4 +94,5 @@
 		<module>function-dependencies</module>
 	</modules>
 
+	<!-- BONO: Removed the <repositories/pluginRepositories> -->
 </project>

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -279,6 +279,9 @@
 			<url>https://repo.spring.io/libs-snapshot-local</url>
 		</snapshotRepository>
 	</distributionManagement>
+
+	<!-- BONO: Removed the <repositories/pluginRepositories> -->
+
 	<profiles>
 		<profile>
 			<id>default</id>


### PR DESCRIPTION
### Background

I had to bang on the main branch a bit to knock the kinks out of the "de-duplication" effort I committed last week. Attempting to re-use `<repositories/pluginRepositories>` turned out to be a bit problematic. I was unable to reproduce locally so ended up doing some commits in main (which I also reverted once I understood what was really going on). I apologize for the messy commit history. 

The purpose of this PR is **NOT** to merge these changes (they are already committed and work) but rather summarize the changes I ultimately made. It would be unfair for me to not take the time to explain this as it would not be fun to try to understand this from the commit history. 

What I did was distill the pertinent changes and added a comment to get the file into this PR. 


### Here we go!

#### Problem
Every single app base pom.xml has the same `<repositories/pluginRepositories>` and violates DRY.

#### Solution (attempt 1)
Delete the `<repositories/pluginRepositories>` out of each app base pom.xml as it is already in its parentage `stream-applications-core/pom.xml`

#### Result
Did not work (unable to download the apps generator plugin). While the `stream-applications-core` artifact is uploaded to JFrog `libs-snapshot-local` w/ the repos info in it, when it is downloaded from the proxy JFrog `snapshot` repo it has its repo info removed by JFrog (this is by design). Again, to summarize, artifacts downloaded from https://repo.spring.io/ui/native/libs-snapshot-local/org/springframework/cloud/stream/app/stream-applications-build/1.2.1-SNAPSHOT/ are not mucked with but artifacts downloaded from the corresponding proxy https://repo.spring.io/ui/native/snapshot/org/springframework/cloud/stream/app/stream-applications-build/1.2.1-SNAPSHOT/ are mucked w/ (repos info removed). 

##### Question
How was the above working for regular deps but not for plugin deps? The reason is that Jenkins uses a maven user settings.xml w/ an active `spring` profile that includes the `<repositories>`  but not the `<pluginRepositories>`. Also note that our `.mvnw` wrapper always enables the `spring` profile.

Ideally we would have Trevor update this Jenkins maven user settings.xml to include the `<pluginRepositories>` but I would be concerned of other teams being affected etc..

#### Solution 2
What I landed on was a maven extension that lets us "add" to the existing maven user settings. This ensures that we have all required repos in all cases. Maven has no way to merge a user settings, only override completely. W/o this extension we would have to replace the existing Maven settings.xml and there are things in there (credentials etc..) that we definitely want to keep in place.

This ensures that when we run the wrapper Maven command we always have all required repos available to us. This approach also allows us to completely remove any `<repositories/pluginRepositories>` from all of our pom.xml files. 
