### PR TITLE
Update main to next version (4.0.0)

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud.stream.app</groupId>
 	<artifactId>applications</artifactId>
-	<version>3.2.2-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<name>applications</name>
 	<description>Infrastructure for stream applications</description>
 	<packaging>pom</packaging>

--- a/applications/processor/aggregator-processor/pom.xml
+++ b/applications/processor/aggregator-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/bridge-processor/pom.xml
+++ b/applications/processor/bridge-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/filter-processor/pom.xml
+++ b/applications/processor/filter-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/groovy-processor/pom.xml
+++ b/applications/processor/groovy-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/header-enricher-processor/pom.xml
+++ b/applications/processor/header-enricher-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/http-request-processor/pom.xml
+++ b/applications/processor/http-request-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/image-recognition-processor/pom.xml
+++ b/applications/processor/image-recognition-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/object-detection-processor/pom.xml
+++ b/applications/processor/object-detection-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/pom.xml
+++ b/applications/processor/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.springframework.cloud.stream.app</groupId>
     <artifactId>processor</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/applications/processor/script-processor/pom.xml
+++ b/applications/processor/script-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/semantic-segmentation-processor/pom.xml
+++ b/applications/processor/semantic-segmentation-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/splitter-processor/pom.xml
+++ b/applications/processor/splitter-processor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/processor/transform-processor/pom.xml
+++ b/applications/processor/transform-processor/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud.stream.app</groupId>
 		<artifactId>stream-applications-core</artifactId>
-		<version>3.2.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/applications/processor/twitter-trend-processor/pom.xml
+++ b/applications/processor/twitter-trend-processor/pom.xml
@@ -6,12 +6,12 @@
     <artifactId>twitter-trend-processor</artifactId>
     <name>twitter-trend-processor</name>
     <description>twitter trend processor apps</description>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/analytics-sink/pom.xml
+++ b/applications/sink/analytics-sink/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/cassandra-sink/pom.xml
+++ b/applications/sink/cassandra-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/elasticsearch-sink/pom.xml
+++ b/applications/sink/elasticsearch-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/file-sink/pom.xml
+++ b/applications/sink/file-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/ftp-sink/pom.xml
+++ b/applications/sink/ftp-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/geode-sink/pom.xml
+++ b/applications/sink/geode-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/jdbc-sink/pom.xml
+++ b/applications/sink/jdbc-sink/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/log-sink/pom.xml
+++ b/applications/sink/log-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/mongodb-sink/pom.xml
+++ b/applications/sink/mongodb-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/mqtt-sink/pom.xml
+++ b/applications/sink/mqtt-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/pgcopy-sink/pom.xml
+++ b/applications/sink/pgcopy-sink/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud.stream.app</groupId>
 		<artifactId>stream-applications-core</artifactId>
-		<version>3.2.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/applications/sink/pom.xml
+++ b/applications/sink/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.springframework.cloud.stream.app</groupId>
     <artifactId>sink</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/applications/sink/rabbit-sink/pom.xml
+++ b/applications/sink/rabbit-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/redis-sink/pom.xml
+++ b/applications/sink/redis-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/router-sink/pom.xml
+++ b/applications/sink/router-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/rsocket-sink/pom.xml
+++ b/applications/sink/rsocket-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/s3-sink/pom.xml
+++ b/applications/sink/s3-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/sftp-sink/pom.xml
+++ b/applications/sink/sftp-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/tcp-sink/pom.xml
+++ b/applications/sink/tcp-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/throughput-sink/pom.xml
+++ b/applications/sink/throughput-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/twitter-message-sink/pom.xml
+++ b/applications/sink/twitter-message-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/twitter-update-sink/pom.xml
+++ b/applications/sink/twitter-update-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/wavefront-sink/pom.xml
+++ b/applications/sink/wavefront-sink/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud.stream.app</groupId>
 		<artifactId>stream-applications-core</artifactId>
-		<version>3.2.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/applications/sink/websocket-sink/pom.xml
+++ b/applications/sink/websocket-sink/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/sink/zeromq-sink/pom.xml
+++ b/applications/sink/zeromq-sink/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/cdc-debezium-source/pom.xml
+++ b/applications/source/cdc-debezium-source/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.cloud.stream.app</groupId>
 		<artifactId>stream-applications-core</artifactId>
-		<version>3.2.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/applications/source/file-source/pom.xml
+++ b/applications/source/file-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/ftp-source/pom.xml
+++ b/applications/source/ftp-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/geode-source/pom.xml
+++ b/applications/source/geode-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <dependencies>

--- a/applications/source/http-source/pom.xml
+++ b/applications/source/http-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/jdbc-source/pom.xml
+++ b/applications/source/jdbc-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/jms-source/pom.xml
+++ b/applications/source/jms-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/load-generator-source/pom.xml
+++ b/applications/source/load-generator-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/mail-source/pom.xml
+++ b/applications/source/mail-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/mongodb-source/pom.xml
+++ b/applications/source/mongodb-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/mqtt-source/pom.xml
+++ b/applications/source/mqtt-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/pom.xml
+++ b/applications/source/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.springframework.cloud.stream.app</groupId>
     <artifactId>source</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/applications/source/rabbit-source/pom.xml
+++ b/applications/source/rabbit-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/s3-source/pom.xml
+++ b/applications/source/s3-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/sftp-source/pom.xml
+++ b/applications/source/sftp-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/syslog-source/pom.xml
+++ b/applications/source/syslog-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/tcp-source/pom.xml
+++ b/applications/source/tcp-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/time-source/pom.xml
+++ b/applications/source/time-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/twitter-message-source/pom.xml
+++ b/applications/source/twitter-message-source/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud.stream.app</groupId>
 		<artifactId>stream-applications-core</artifactId>
-		<version>3.2.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/applications/source/twitter-search-source/pom.xml
+++ b/applications/source/twitter-search-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/twitter-stream-source/pom.xml
+++ b/applications/source/twitter-stream-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/websocket-source/pom.xml
+++ b/applications/source/websocket-source/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/source/zeromq-source/pom.xml
+++ b/applications/source/zeromq-source/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -11,14 +11,14 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-build</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
     <properties>
-        <revision>3.2.2-SNAPSHOT</revision>
+        <revision>4.0.0-SNAPSHOT</revision>
         <stream-apps-core.version>${revision}</stream-apps-core.version>
-        <java-functions.version>1.2.2-SNAPSHOT</java-functions.version>
+        <java-functions.version>4.0.0-SNAPSHOT</java-functions.version>
         <apps.base-image>springcloud/baseimage:1.0.1</apps.base-image>
         <spring-cloud-dataflow-apps-generator-plugin.version>1.0.7</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.7</spring-cloud-dataflow-apps-docs-plugin.version>

--- a/etc/release-tools/apps-upgrade-after-ga.sh
+++ b/etc/release-tools/apps-upgrade-after-ga.sh
@@ -26,7 +26,7 @@ function iterate_through_apps_folders_and_update {
     ../../../mvnw -Ddisable.checks=true versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false
     #../../../mvnw -Ddisable.checks=true versions:update-parent -DparentVersion=$PARENT_VERSION -Pspring -DgenerateBackupPoms=false
     # only used after a release for updating parent versions.
-    sed -i '' 's/<version>3.2.1/<version>'3.2.2-SNAPSHOT'/g' pom.xml
+    sed -i '' 's/<version>3.2.2-SNAPSHOT/<version>'4.0.0-SNAPSHOT'/g' pom.xml
     popd
   done
 

--- a/functions/pom.xml
+++ b/functions/pom.xml
@@ -13,12 +13,12 @@
 	<parent>
 		<groupId>org.springframework.cloud.stream.app</groupId>
 		<artifactId>stream-applications-build</artifactId>
-		<version>1.2.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 
 	<properties>
-		<revision>1.2.2-SNAPSHOT</revision>
+		<revision>4.0.0-SNAPSHOT</revision>
 	</properties>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.springframework.cloud.stream.app</groupId>
     <artifactId>stream-applications</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>stream-applications</name>
     <description>Functions and Infrastructure for stream applications</description>
     <packaging>pom</packaging>

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.cloud.stream.app</groupId>
 	<artifactId>stream-applications-build</artifactId>
-	<version>1.2.2-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<name>stream-applications-build</name>
 	<description>Common Parent for Functions and Applications</description>
 	<packaging>pom</packaging>

--- a/stream-applications-release-train/pom.xml
+++ b/stream-applications-release-train/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>stream-applications-core</artifactId>
-        <version>3.2.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../applications/stream-applications-core/pom.xml</relativePath>
     </parent>
 
@@ -19,8 +19,8 @@
     </modules>
 
     <properties>
-        <revision>2021.1.3-SNAPSHOT</revision>
-        <apps.version>3.2.2-SNAPSHOT</apps.version>
+        <revision>2022.0.0-SNAPSHOT</revision>
+        <apps.version>4.0.0-SNAPSHOT</apps.version>
         <apps.harbor.version>3.2.0</apps.harbor.version>
         <apps.docker.tag>${apps.version}</apps.docker.tag>
     </properties>


### PR DESCRIPTION
* Bumps apps/core version from `3.2.2 -> 4.0.0` 
* Jumps version number on functions from `1.2.2 -> 4.0.0`
* Bumps release train version from `2021.1.3 -> 2022.0.0`

All version numbers are in sync now. 