### PR TITLE
Disable DB init for JDBC Source and Sink

### DIFF
--- a/functions/consumer/jdbc-consumer/src/main/resources/application.properties
+++ b/functions/consumer/jdbc-consumer/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.integration.jdbc.initialize-schema=NEVER

--- a/functions/function/http-request-function/src/main/java/org/springframework/cloud/fn/http/request/HttpRequestFunctionConfiguration.java
+++ b/functions/function/http-request-function/src/main/java/org/springframework/cloud/fn/http/request/HttpRequestFunctionConfiguration.java
@@ -23,7 +23,6 @@ import java.util.function.Function;
 import reactor.core.publisher.Flux;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;

--- a/functions/supplier/jdbc-supplier/src/main/resources/application.properties
+++ b/functions/supplier/jdbc-supplier/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.integration.jdbc.initialize-schema=NEVER

--- a/functions/supplier/jdbc-supplier/src/test/java/org/springframework/cloud/fn/supplier/jdbc/DefaultJdbcSupplierTests.java
+++ b/functions/supplier/jdbc-supplier/src/test/java/org/springframework/cloud/fn/supplier/jdbc/DefaultJdbcSupplierTests.java
@@ -82,6 +82,11 @@ public class DefaultJdbcSupplierTests {
 		stepVerifier.verify();
 	}
 
+	/*
+	The test to verify that DB is not initialized with Spring Integration DDL
+	(spring.integration.jdbc.initialize-schema=NEVER) what happens by default via IntegrationAutoConfiguration.IntegrationJdbcConfiguration.
+	This is not a functionality of this JDBC Supplier.
+	 */
 	@Test
 	void verifyNoIntMessageGroupTable() {
 		assertThatExceptionOfType(BadSqlGrammarException.class)

--- a/functions/supplier/jdbc-supplier/src/test/java/org/springframework/cloud/fn/supplier/jdbc/DefaultJdbcSupplierTests.java
+++ b/functions/supplier/jdbc-supplier/src/test/java/org/springframework/cloud/fn/supplier/jdbc/DefaultJdbcSupplierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,13 @@ import reactor.test.StepVerifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = "jdbc.supplier.query=select id, name from test order by id")
@@ -38,6 +41,9 @@ public class DefaultJdbcSupplierTests {
 
 	@Autowired
 	Supplier<Flux<Message<?>>> jdbcSupplier;
+
+	@Autowired
+	JdbcTemplate jdbcTemplate;
 
 	@Test
 	void testExtraction() {
@@ -74,6 +80,13 @@ public class DefaultJdbcSupplierTests {
 						.thenCancel()
 						.verifyLater();
 		stepVerifier.verify();
+	}
+
+	@Test
+	void verifyNoIntMessageGroupTable() {
+		assertThatExceptionOfType(BadSqlGrammarException.class)
+				.isThrownBy(() -> this.jdbcTemplate.queryForList("SELECT * FROM INT_MESSAGE_GROUP"))
+				.withMessageContaining("Table \"INT_MESSAGE_GROUP\" not found;");
 	}
 
 	@SpringBootApplication

--- a/functions/supplier/mail-supplier/src/main/java/org/springframework/cloud/fn/supplier/mail/MailSupplierConfiguration.java
+++ b/functions/supplier/mail-supplier/src/main/java/org/springframework/cloud/fn/supplier/mail/MailSupplierConfiguration.java
@@ -24,7 +24,6 @@ import java.util.function.Supplier;
 import javax.mail.URLName;
 
 import org.reactivestreams.Publisher;
-
 import reactor.core.publisher.Flux;
 
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
The `IntegrationAutoConfiguration` provides mechanism to initialize DB with some out-of-the-box scripts. The default behavior is `EMBEDDED` even if we don't use any components for those DB objects, e.g. no `JdbcMessageStore` bean.

* Add `spring.integration.jdbc.initialize-schema=NEVER` to the `jdbc-consumer` and `jdbc-supplier` to not attempt to initialize DB
* Fix Checkstyle violations in other modules