### PR TITLE
GH-369: Fix HeaderEnricher for no proxyBeanMethod

### DIFF
--- a/applications/processor/header-enricher-processor/src/test/java/org/springframework/cloud/stream/app/processor/header/enricher/HeaderEnricherProcessorTests.java
+++ b/applications/processor/header-enricher-processor/src/test/java/org/springframework/cloud/stream/app/processor/header/enricher/HeaderEnricherProcessorTests.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.stream.app.processor.header.enricher;
 
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -40,7 +39,6 @@ import static org.hamcrest.Matchers.equalTo;
  * @author Christian Tzolov
  * @author Soby Chacko
  */
-@Disabled
 public class HeaderEnricherProcessorTests {
 
 	@Test

--- a/functions/function/header-enricher-function/src/test/java/org/springframework/cloud/fn/header/enricher/HeaderEnricherFunctionApplicationTests.java
+++ b/functions/function/header-enricher-function/src/test/java/org/springframework/cloud/fn/header/enricher/HeaderEnricherFunctionApplicationTests.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.fn.header.enricher;
 
 import java.util.function.Function;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +41,6 @@ import static org.hamcrest.Matchers.equalTo;
 		"header.enricher.headers=foo='bar' \\n baz='fiz' \\n buz=payload \\n jaz=@value",
 		"header.enricher.overwrite = true" })
 @DirtiesContext
-@Disabled
 public class HeaderEnricherFunctionApplicationTests {
 
 	@Autowired


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/369

Spring Boot `@AutoConfiguration` comes now with a `proxyBeanMethods = false`, so we cannot call bean methods within the same configuration class

* Rework `HeaderEnricherFunctionConfiguration` for bean methods autowiring
* Create an `ExpressionEvaluatingHeaderValueMessageProcessor` instances directly in the `headerEnricher` bean definition and propagate an injected `BeanFactory`