### PR TITLE
GH-373: Re-enable aggregator tests

### DIFF
--- a/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionProperties.java
+++ b/functions/function/aggregator-function/src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionProperties.java
@@ -117,8 +117,6 @@ public class AggregatorFunctionProperties {
 
 		static final String REDIS = "redis";
 
-		static final String GEMFIRE = "gemfire";
-
 	}
 
 }

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/CustomPropsAndMongoMessageStoreAggregatorTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.fn.aggregator;
 import java.time.Duration;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -47,7 +46,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"aggregator.message-store-entity=aggregatorTest"
 })
 @AutoConfigureDataMongo
-@Disabled
 public class CustomPropsAndMongoMessageStoreAggregatorTests extends AbstractAggregatorFunctionTests
 		implements MongoDbTestContainerSupport {
 

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/DefaultAggregatorTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.fn.aggregator;
 import java.time.Duration;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -35,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  * @author Corneil du Plessis
  */
-@Disabled
 public class DefaultAggregatorTests extends AbstractAggregatorFunctionTests {
 
 	@Test

--- a/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
+++ b/functions/function/aggregator-function/src/test/java/org/springframework/cloud/fn/aggregator/JdbcMessageStoreAggregatorTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.fn.aggregator;
 import java.time.Duration;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -37,7 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Corneil du Plessis
  */
 @TestPropertySource(properties = "aggregator.message-store-type=jdbc")
-@Disabled
 public class JdbcMessageStoreAggregatorTests extends AbstractAggregatorFunctionTests {
 
 	@Test

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -49,7 +49,7 @@
 		<spring-cloud-function.version>4.0.0-SNAPSHOT</spring-cloud-function.version>
 		<spring-cloud-stream-dependencies.version>4.0.0-SNAPSHOT</spring-cloud-stream-dependencies.version>
 		<spring-cloud-stream.version>4.0.0-SNAPSHOT</spring-cloud-stream.version>
-		<test-containers.version>1.16.3</test-containers.version>
+		<test-containers.version>1.17.5</test-containers.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<mockserver.version>5.13.2</mockserver.version>
 
@@ -135,6 +135,7 @@
 				</executions>
 				<configuration>
 					<quiet>true</quiet>
+					<doclint>syntax</doclint>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/373

The fix in Spring Integration has made it into the latest SNAPSHOT. See more info in the linked issue

* Update to the latest Testcontainers: it does not require credential for pull command any more
* Remove obsolete `MessageStoreType.GEMFIRE`
* Add `<doclint>syntax</doclint>` to ignore missed javadocs on public methods