### PR TITLE
GH-370: Enable ScriptProcessor tests back

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           version: 'latest'
           java-version: '17'
-          #          components: 'native-image' # add when starting native builds.
+          components: 'js'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Configure: cache for maven dependencies'
         uses: actions/cache@v3

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           version: 'latest'
           java-version: ${{ needs.parameters.outputs.jdk_build }}
-#          components: 'native-image' # add when starting native builds.
+          components: 'js'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Configure: cache for maven dependencies'
         uses: actions/cache@v3
@@ -277,7 +277,7 @@ jobs:
         with:
           version: 'latest'
           java-version: ${{ needs.parameters.outputs.jdk_build }}
-#          components: 'native-image' # add when starting native builds.
+          components: 'js'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Configure: cache for maven dependencies'
         uses: actions/cache@v3
@@ -357,7 +357,7 @@ jobs:
         with:
           version: 'latest'
           java-version: ${{ needs.parameters.outputs.jdk_build }}
-#          components: 'native-image' # add when starting native builds.
+          components: 'js'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Configure: cache for maven dependencies'
         uses: actions/cache@v3
@@ -437,7 +437,7 @@ jobs:
         with:
           version: 'latest'
           java-version: ${{ needs.parameters.outputs.jdk_build }}
-#          components: 'native-image' # add when starting native builds.
+          components: 'js'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Configure: cache for maven dependencies'
         uses: actions/cache@v3
@@ -514,7 +514,7 @@ jobs:
         with:
           version: 'latest'
           java-version: ${{ needs.parameters.outputs.jdk_build }}
-          #          components: 'native-image' # add when starting native builds.
+          components: 'js'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Configure: cache for maven dependencies'
         uses: actions/cache@v3

--- a/applications/processor/script-processor/pom.xml
+++ b/applications/processor/script-processor/pom.xml
@@ -18,12 +18,24 @@
         <jruby-complete.version>9.3.9.0</jruby-complete.version>
         <jython-standalone.version>2.7.3</jython-standalone.version>
         <apache-ivy.version>2.5.1</apache-ivy.version>
+        <graalvm.version>22.3.0</graalvm.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-groovy</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>${graalvm.version}</version>
         </dependency>
 
         <dependency>

--- a/applications/processor/script-processor/pom.xml
+++ b/applications/processor/script-processor/pom.xml
@@ -15,8 +15,8 @@
     </parent>
 
     <properties>
-        <jruby-complete.version>9.0.5.0</jruby-complete.version>
-        <jython-standalone.version>2.7.2</jython-standalone.version>
+        <jruby-complete.version>9.3.9.0</jruby-complete.version>
+        <jython-standalone.version>2.7.3</jython-standalone.version>
         <apache-ivy.version>2.5.1</apache-ivy.version>
     </properties>
 
@@ -78,6 +78,17 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/applications/processor/script-processor/src/test/java/org/springframework/cloud/stream/app/processor/script/ScriptProcessorIntegrationTests.java
+++ b/applications/processor/script-processor/src/test/java/org/springframework/cloud/stream/app/processor/script/ScriptProcessorIntegrationTests.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -46,7 +45,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ScriptProcessorIntegrationTests {
 
-	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testJavascriptFunctions() throws IOException {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -68,7 +66,6 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testJavascriptVariableTake1() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -88,7 +85,6 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testJavascriptVariableTake2() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -218,7 +214,6 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testGroovyToJavascript() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(

--- a/applications/processor/script-processor/src/test/java/org/springframework/cloud/stream/app/processor/script/ScriptProcessorIntegrationTests.java
+++ b/applications/processor/script-processor/src/test/java/org/springframework/cloud/stream/app/processor/script/ScriptProcessorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package org.springframework.cloud.stream.app.processor.script;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ScriptProcessorIntegrationTests {
 
-	@Disabled
+	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testJavascriptFunctions() throws IOException {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -68,7 +68,7 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@Disabled
+	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testJavascriptVariableTake1() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -88,7 +88,7 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@Disabled
+	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testJavascriptVariableTake2() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -104,7 +104,7 @@ public class ScriptProcessorIntegrationTests {
 
 			processorInput.send(new GenericMessage<>(9));
 			Message<byte[]> sourceMessage = processorOutput.receive(10000, "scriptProcessorFunction-out-0");
-			assertThat(new String(sourceMessage.getPayload())).isEqualTo("45.0");
+			assertThat(new String(sourceMessage.getPayload())).isEqualTo("45");
 		}
 	}
 
@@ -146,7 +146,6 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@Disabled
 	@Test
 	public void testRubyScript() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -165,7 +164,6 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@Disabled
 	@Test
 	public void testRubyScriptComplex() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -220,7 +218,7 @@ public class ScriptProcessorIntegrationTests {
 		}
 	}
 
-	@Disabled
+	@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 	@Test
 	public void testGroovyToJavascript() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -241,7 +239,8 @@ public class ScriptProcessorIntegrationTests {
 	}
 
 	@EnableAutoConfiguration
-	@Import({ScriptProcessorConfiguration.class})
+	@Import(ScriptProcessorConfiguration.class)
 	public static class ScriptProcessorTestConfiguration {
 	}
+
 }

--- a/etc/checkstyle/checkstyle.xml
+++ b/etc/checkstyle/checkstyle.xml
@@ -20,9 +20,8 @@
 		<property name="headerFile" value="${checkstyle.header.file}"/>
 		<property name="fileExtensions" value="java,groovy"/>
 	</module>
-	<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck">
-		<property name="lineSeparator" value="lf"/>
-	</module>
+
+	<module name="NewlineAtEndOfFile"/>
 
 	<!-- TreeWalker Checks -->
 	<module name="com.puppycrawl.tools.checkstyle.TreeWalker">


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/370

* Update dependencies for `script-processor`
* Add `maven-surefire-plugin` to `script-processor` POM and specify `--add-opens` for Ruby requirements
* Mark all JavaScript tests with `@EnabledIfSystemProperty` against `org.graalvm.language.js.home` which is available only if GraalVM with `js` component enabled
* Fix `NewlineAtEndOfFile` rule for Checkstyle since on Windows the line end is `crlf`
* Add `components: 'js'` to GraalVM installation steps for all the GH action scripts