### PR TITLE
GH-330: Rework Router Sink for `StreamBridge`

### DIFF
--- a/applications/sink/router-sink/README.adoc
+++ b/applications/sink/router-sink/README.adoc
@@ -18,51 +18,25 @@ $$router.variables$$:: $$Variable bindings as a new line delimited string of nam
 $$router.variables-location$$:: $$The location of a properties file containing custom script variable bindings.$$ *($$Resource$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
-NOTE: Since this is a dynamic router, destinations are created as needed; therefore, by default the `defaultOutputChannel`
-and `resolutionRequired` will only be used if the `Binder` has some problem binding to the destination.
+NOTE: This router sink is based on a `StreamBridge` API from Spring Cloud Stream, therefore destinations can be created as needed.
+In this case a `defaultOutputBinding` can only be reached if key is not included into `destinationMappings`.
+The `resolutionRequired = true` neglects `defaultOutputBinding` and throws an exception if no mapping and no respective binding already declared.
 
 You can restrict the creation of dynamic bindings using the `spring.cloud.stream.dynamicDestinations` property.
-By default, all resolved destinations will be bound dynamically; if this property has a comma-delimited list of
-destination names, only those will be bound.
-Messages that resolve to a destination that is not in this list will be routed to the `defaultOutputChannel`, which
-must also appear in the list.
+By default, all resolved destinations will be bound dynamically; if this property has a comma-delimited list of destination names, only those will be bound.
+Messages that resolve to a destination that is not in this list will be routed to the `defaultOutputBinding`, which must also appear in the list.
 
-`destinationMappings` are used to map the evaluation results to an actual destination name.
+The `destinationMappings` are used to map the evaluation results to an actual destination name.
 
 == SpEL-based Routing
 
 The expression evaluates against the message and returns either a channel name, or the key to a map of channel names.
 
-For more information, please see the "Routers and the Spring Expression Language (SpEL)" subsection in the Spring
-Integration Reference manual
-https://docs.spring.io/spring-integration/reference/html/router.html#router-namespace[Configuring a Generic Router] section.
-
-NOTE: Starting with Spring Cloud Stream 2.0 onwards the message wire format for `json`, `text` and `xml` content types is `byte[]` not `String`!
-This is an altering change from SCSt 1.x that treats those types as Strings!
-Depends on the content type, different techniques for handling the `byte[]` payloads are available. For plain `text`
-content types, one can covert the octet payload into string using the `new String(payload)` SpEL expression. For `json`
-types the https://docs.spring.io/spring-integration/reference/html/spel.html#spel-functions[jsonPath()] SpEL utility
-already supports string and byte array content interchangeably. Same applies for the `xml` content type and the
-https://docs.spring.io/spring-integration/reference/html/xml.html#xpath-spel-function[#xpath()] SpEL utility.
-
-For example for `text` content type one should use:
-
-[source,java]
-----
- new String(payload).contains('a');
-----
-
-and for `json` content type SpEL expressions like this:
-
-[source,text]
-----
- #jsonPath(payload, '$.person.name')
-----
+For more information, please see the "Routers and the Spring Expression Language (SpEL)" subsection in the Spring Integration Reference manual https://docs.spring.io/spring-integration/reference/html/router.html#router-namespace[Configuring a Generic Router] section.
 
 == Groovy-based Routing
 
-Instead of SpEL expressions, Groovy scripts can also be used. Let's create a Groovy script in the file system at
-"file:/my/path/router.groovy", or "classpath:/my/path/router.groovy" :
+Instead of SpEL expressions, Groovy scripts can also be used. Let's create a Groovy script in the file system at "file:/my/path/router.groovy", or "classpath:/my/path/router.groovy" :
 
 [source,groovy]
 ----
@@ -75,15 +49,10 @@ else {
 }
 ----
 
-If you want to pass variable values to your script, you can statically bind values using the _variables_ option or
-optionally pass the path to a properties file containing the bindings using the _propertiesLocation_ option.
-All properties in the file will be made available to the script as variables. You may specify both _variables_ and
-_propertiesLocation_, in which case any duplicate values provided as _variables_ override values provided in
-_propertiesLocation_.
+If you want to pass variable values to your script, you can statically bind values using the _variables_ option or optionally pass the path to a properties file containing the bindings using the _propertiesLocation_ option.
+All properties in the file will be made available to the script as variables. You may specify both _variables_ and _propertiesLocation_, in which case any duplicate values provided as _variables_ override values provided in _propertiesLocation_.
 Note that _payload_ and _headers_ are implicitly bound to give you access to the data contained in a message.
 
-For more information, see the Spring Integration Reference manual
-https://docs.spring.io/spring-integration/reference/html/messaging-endpoints-chapter.html#groovy[Groovy Support].
+For more information, see the Spring Integration Reference manual https://docs.spring.io/spring-integration/reference/html/messaging-endpoints-chapter.html#groovy[Groovy Support].
 
 //end::ref-doc[]
-

--- a/applications/sink/router-sink/README.adoc
+++ b/applications/sink/router-sink/README.adoc
@@ -8,11 +8,11 @@ This application routes messages to named channels.
 The **$$router$$** $$sink$$ has the following options:
 
 //tag::configuration-properties[]
-$$router.default-output-channel$$:: $$Where to send un-routable messages.$$ *($$String$$, default: `$$nullChannel$$`)*
+$$router.default-output-binding$$:: $$Where to send un-routable messages.$$ *($$String$$, default: `$$<none>$$`)*
 $$router.destination-mappings$$:: $$Destination mappings as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.$$ *($$Properties$$, default: `$$<none>$$`)*
 $$router.expression$$:: $$The expression to be applied to the message to determine the channel(s) to route to. Note that the payload wire format for content types such as text, json or xml is byte[] not String!. Consult the documentation for how to handle byte array payload content.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$router.refresh-delay$$:: $$How often to check for script changes in ms (if present); < 0 means don't refresh.$$ *($$Integer$$, default: `$$60000$$`)*
-$$router.resolution-required$$:: $$Whether or not channel resolution is required.$$ *($$Boolean$$, default: `$$false$$`)*
+$$router.resolution-required$$:: $$Whether channel resolution is required.$$ *($$Boolean$$, default: `$$false$$`)*
 $$router.script$$:: $$The location of a groovy script that returns channels or channel mapping resolution keys.$$ *($$Resource$$, default: `$$<none>$$`)*
 $$router.variables$$:: $$Variable bindings as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.$$ *($$Properties$$, default: `$$<none>$$`)*
 $$router.variables-location$$:: $$The location of a properties file containing custom script variable bindings.$$ *($$Resource$$, default: `$$<none>$$`)*

--- a/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/BindingChannelResolver.java
+++ b/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/BindingChannelResolver.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.sink.router;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.cloud.stream.binding.BindingService;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolutionException;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * @author Artem Bilan
+ */
+class BindingChannelResolver implements DestinationResolver<MessageChannel> {
+
+	private final Map<String, MessageChannel> bindingChannelCache = new ConcurrentHashMap<>();
+
+	private final BindingService bindingService;
+
+	private final StreamBridge streamBridge;
+
+	private boolean resolutionRequired;
+
+	BindingChannelResolver(BindingService bindingService, StreamBridge streamBridge) {
+		this.bindingService = bindingService;
+		this.streamBridge = streamBridge;
+	}
+
+	public void setResolutionRequired(boolean resolutionRequired) {
+		this.resolutionRequired = resolutionRequired;
+	}
+
+	@Override
+	public MessageChannel resolveDestination(String name) throws DestinationResolutionException {
+		return this.bindingChannelCache.computeIfAbsent(name, this::createMessageChannelProxyForBinding);
+	}
+
+	private MessageChannel createMessageChannelProxyForBinding(String bindingName) {
+		if (this.resolutionRequired &&
+				// TODO Need BindingService.getBinding(String bindingName) API
+				!ObjectUtils.containsElement(this.bindingService.getProducerBindingNames(), bindingName)) {
+
+			throw new DestinationResolutionException("Binding for name [" + bindingName + "] is not provided.");
+		}
+
+		return (message, timeout) -> this.streamBridge.send(bindingName, message);
+	}
+
+}

--- a/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/BindingChannelResolver.java
+++ b/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/BindingChannelResolver.java
@@ -37,14 +37,11 @@ class BindingChannelResolver implements DestinationResolver<MessageChannel> {
 
 	private final StreamBridge streamBridge;
 
-	private boolean resolutionRequired;
+	private final boolean resolutionRequired;
 
-	BindingChannelResolver(BindingService bindingService, StreamBridge streamBridge) {
+	BindingChannelResolver(BindingService bindingService, StreamBridge streamBridge, boolean resolutionRequired) {
 		this.bindingService = bindingService;
 		this.streamBridge = streamBridge;
-	}
-
-	public void setResolutionRequired(boolean resolutionRequired) {
 		this.resolutionRequired = resolutionRequired;
 	}
 

--- a/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/BindingChannelResolver.java
+++ b/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/BindingChannelResolver.java
@@ -24,7 +24,6 @@ import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.core.DestinationResolver;
-import org.springframework.util.ObjectUtils;
 
 /**
  * @author Artem Bilan
@@ -51,10 +50,7 @@ class BindingChannelResolver implements DestinationResolver<MessageChannel> {
 	}
 
 	private MessageChannel createMessageChannelProxyForBinding(String bindingName) {
-		if (this.resolutionRequired &&
-				// TODO Need BindingService.getBinding(String bindingName) API
-				!ObjectUtils.containsElement(this.bindingService.getProducerBindingNames(), bindingName)) {
-
+		if (this.resolutionRequired && this.bindingService.getProducerBinding(bindingName) == null) {
 			throw new DestinationResolutionException("Binding for name [" + bindingName + "] is not provided.");
 		}
 

--- a/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkConfiguration.java
+++ b/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkConfiguration.java
@@ -86,9 +86,8 @@ public class RouterSinkConfiguration {
 			router.replaceChannelMappings(destinationMappings);
 		}
 
-		BindingChannelResolver bindingChannelResolver = new BindingChannelResolver(bindingService, streamBridge);
-		bindingChannelResolver.setResolutionRequired(this.properties.isResolutionRequired());
-		router.setChannelResolver(bindingChannelResolver);
+		router.setChannelResolver(
+				new BindingChannelResolver(bindingService, streamBridge, this.properties.isResolutionRequired()));
 		return router;
 	}
 

--- a/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkConfiguration.java
+++ b/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,30 @@
 package org.springframework.cloud.stream.app.sink.router;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.Consumer;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.binding.BindingService;
+import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
-import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.router.ExpressionEvaluatingRouter;
-import org.springframework.integration.router.MessageRouter;
 import org.springframework.integration.router.MethodInvokingRouter;
-import org.springframework.integration.scripting.DefaultScriptVariableGenerator;
-import org.springframework.integration.scripting.RefreshableResourceScriptSource;
-import org.springframework.integration.scripting.ScriptVariableGenerator;
+import org.springframework.integration.scripting.dsl.Scripts;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
-import org.springframework.scripting.ScriptSource;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * A sink app that routes to one or more named channels.
@@ -48,85 +50,72 @@ import org.springframework.util.CollectionUtils;
  * @author Christian Tzolov
  * @author Soby Chacko
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(RouterSinkProperties.class)
 public class RouterSinkConfiguration {
 
-	@Autowired
-	RouterSinkProperties properties;
+	private final RouterSinkProperties properties;
 
-	@Bean
-	public Consumer<Message<?>> routerSinkConsumer(MessageRouter router) {
-		return ((AbstractMessageRouter) router)::handleMessage;
+	public RouterSinkConfiguration(RouterSinkProperties properties) {
+		this.properties = properties;
 	}
 
 	@Bean
-	public MessageRouter router(//BinderAwareChannelResolver channelResolver,
-								ScriptVariableGenerator scriptVariableGenerator) {
+	public Consumer<Message<?>> routerSinkConsumer(AbstractMessageRouter router) {
+		return router::handleMessage;
+	}
+
+	@Bean
+	public AbstractMessageRouter router(BindingService bindingService, StreamBridge streamBridge,
+			@Nullable MessageProcessor<?> scriptProcessor) {
+
 		AbstractMappingMessageRouter router;
-		if (properties.getScript() != null) {
-			router = new MethodInvokingRouter(scriptProcessor(scriptVariableGenerator, properties));
+		if (scriptProcessor != null) {
+			router = new MethodInvokingRouter(scriptProcessor);
 		}
 		else {
-			router = new ExpressionEvaluatingRouter(properties.getExpression());
+			router = new ExpressionEvaluatingRouter(this.properties.getExpression());
 		}
-		router.setDefaultOutputChannelName(properties.getDefaultOutputChannel());
-		router.setResolutionRequired(properties.isResolutionRequired());
-		if (properties.getDestinationMappings() != null) {
-			router.replaceChannelMappings(properties.getDestinationMappings());
+		String defaultOutputBinding = this.properties.getDefaultOutputBinding();
+		if (StringUtils.hasText(defaultOutputBinding)) {
+			router.setDefaultOutputChannelName(defaultOutputBinding);
 		}
-		//router.setChannelResolver(channelResolver);
+		router.setResolutionRequired(this.properties.isResolutionRequired());
+		Properties destinationMappings = this.properties.getDestinationMappings();
+		if (destinationMappings != null) {
+			router.replaceChannelMappings(destinationMappings);
+		}
+
+		BindingChannelResolver bindingChannelResolver = new BindingChannelResolver(bindingService, streamBridge);
+		bindingChannelResolver.setResolutionRequired(this.properties.isResolutionRequired());
+		router.setChannelResolver(bindingChannelResolver);
 		return router;
-	}
-
-	// Router sink receives the input as String through byteArrayTextToString|routerSinkConsumer.
-	// Spring Cloud Stream used to convert the string back to byte[], but the commit below removed that logic.
-	// https://github.com/spring-cloud/spring-cloud-stream/commit/5d9de8ad579d3464d1503d1a5d1390168bccbdb9
-	// Therefore we are adding it back in the router sink app by programmatically converting the String back to
-	// byte[] before sending it out to the bound router channel.
-	/*
-	@Bean
-	public BinderAwareChannelResolver.NewDestinationBindingCallback newDestinationBindingCallback(CompositeMessageConverter messageConverter) {
-		return new BinderAwareChannelResolver.NewDestinationBindingCallback() {
-			@Override
-			public void configure(String channelName, MessageChannel channel, ProducerProperties producerProperties, Object extendedProducerProperties) {
-				((AbstractMessageChannel) channel).addInterceptor(new ChannelInterceptor() {
-					@Override
-					public Message<?> preSend(Message<?> message, MessageChannel channel) {
-						@SuppressWarnings("unchecked")
-						Message<byte[]> outboundMessage = message.getPayload() instanceof byte[]
-								? (Message<byte[]>) message : (Message<byte[]>) messageConverter
-								.toMessage(message.getPayload(), message.getHeaders());
-						if (outboundMessage == null) {
-							throw new IllegalStateException("Failed to convert message: '" + message
-									+ "' to outbound message.");
-						}
-						return outboundMessage;
-					}
-				});
-			}
-		};
-	}
-	*/
-
-	@Bean(name = "variableGenerator")
-	public ScriptVariableGenerator scriptVariableGenerator() throws IOException {
-		Map<String, Object> variables = new HashMap<>();
-		CollectionUtils.mergePropertiesIntoMap(properties.getVariables(), variables);
-		if (properties.getVariablesLocation() != null) {
-			CollectionUtils.mergePropertiesIntoMap(
-					PropertiesLoaderUtils.loadProperties(properties.getVariablesLocation()), variables);
-		}
-		return new DefaultScriptVariableGenerator(variables);
 	}
 
 	@Bean
 	@ConditionalOnProperty("router.script")
-	public GroovyScriptExecutingMessageProcessor scriptProcessor(ScriptVariableGenerator scriptVariableGenerator,
-																RouterSinkProperties properties) {
-		ScriptSource scriptSource = new RefreshableResourceScriptSource(properties.getScript(),
-				properties.getRefreshDelay());
-		return new GroovyScriptExecutingMessageProcessor(scriptSource, scriptVariableGenerator);
+	public MessageProcessor<?> scriptProcessor() {
+		return Scripts.processor(this.properties.getScript())
+				.lang("groovy")
+				.refreshCheckDelay(this.properties.getRefreshDelay())
+				.variables(obtainScriptVariables(this.properties))
+				.get();
+	}
+
+	private static Map<String, Object> obtainScriptVariables(RouterSinkProperties properties) {
+		Map<String, Object> variables = new HashMap<>();
+		CollectionUtils.mergePropertiesIntoMap(properties.getVariables(), variables);
+		Resource variablesLocation = properties.getVariablesLocation();
+		if (variablesLocation != null) {
+			try {
+				Properties props = PropertiesLoaderUtils.loadProperties(properties.getVariablesLocation());
+				CollectionUtils.mergePropertiesIntoMap(props, variables);
+			}
+			catch (IOException ex) {
+				throw new UncheckedIOException(ex);
+			}
+		}
+		return variables;
 	}
 
 }

--- a/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkProperties.java
+++ b/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.messaging.Message;
  * the channel mappings map.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @ConfigurationProperties("router")
 public class RouterSinkProperties {
@@ -74,10 +75,10 @@ public class RouterSinkProperties {
 	/**
 	 * Where to send un-routable messages.
 	 */
-	private String defaultOutputChannel = "nullChannel";
+	private String defaultOutputBinding;
 
 	/**
-	 * Whether or not channel resolution is required.
+	 * Whether channel resolution is required.
 	 */
 	private boolean resolutionRequired = false;
 
@@ -118,13 +119,12 @@ public class RouterSinkProperties {
 		this.script = script;
 	}
 
-	@NotNull
-	public String getDefaultOutputChannel() {
-		return this.defaultOutputChannel;
+	public String getDefaultOutputBinding() {
+		return this.defaultOutputBinding;
 	}
 
-	public void setDefaultOutputChannel(String defaultOutputChannel) {
-		this.defaultOutputChannel = defaultOutputChannel;
+	public void setDefaultOutputBinding(String defaultOutputBinding) {
+		this.defaultOutputBinding = defaultOutputBinding;
 	}
 
 	public int getRefreshDelay() {

--- a/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkProperties.java
+++ b/applications/sink/router-sink/src/main/java/org/springframework/cloud/stream/app/sink/router/RouterSinkProperties.java
@@ -20,7 +20,6 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
@@ -42,7 +41,8 @@ public class RouterSinkProperties {
 	/**
 	 * Default SpEL expression.
 	 */
-	public static final Expression DEFAULT_EXPRESSION = new FunctionExpression<>((Function<Message<?>, Object>) message -> message.getHeaders().get("routeTo"));
+	public static final Expression DEFAULT_EXPRESSION =
+			new FunctionExpression<>((Function<Message<?>, Object>) message -> message.getHeaders().get("routeTo"));
 
 	/**
 	 * Variable bindings as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.

--- a/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
+++ b/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.app.sink.router;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RouterSinkIntegrationTests {
 
+	@Disabled("See TODO in the config below")
 	@Test
 	public void testDefaultRouter() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -124,6 +126,7 @@ public class RouterSinkIntegrationTests {
 		}
 	}
 
+	@Disabled("See TODO in the config below")
 	@Test
 	public void testWithDiscardedChannels() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(

--- a/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
+++ b/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RouterSinkIntegrationTests {
 
-	@Disabled("See TODO in the config below")
 	@Test
 	public void testDefaultRouter() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -42,7 +41,6 @@ public class RouterSinkIntegrationTests {
 				.web(WebApplicationType.NONE)
 				.run("--spring.cloud.function.definition=routerSinkConsumer",
 						"--spring.cloud.stream.output-bindings=baz",
-						// TODO SCST tries to resolve 'baz' function for some reason
 						"--spring.cloud.stream.function.bindings.baz-out-0=baz",
 						"--router.resolutionRequired=true")) {
 

--- a/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
+++ b/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.stream.app.sink.router;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
+++ b/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.app.sink.router;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -122,7 +121,6 @@ public class RouterSinkIntegrationTests {
 		}
 	}
 
-	@Disabled("See TODO in the config below")
 	@Test
 	public void testWithDiscardedChannels() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
@@ -130,10 +128,12 @@ public class RouterSinkIntegrationTests {
 				.web(WebApplicationType.NONE)
 				.run("--spring.cloud.function.definition=routerSinkConsumer",
 						"--router.expression=headers['route']",
-						// TODO Need a consistency in SCST between dynamic and predefined bindings: it requires an -out-0 suffix now
 						"--router.defaultOutputBinding=discards",
 						"--router.destinationMappings=foo=foo \n bar=bar",
-						"--spring.cloud.stream.output-bindings=foo;bar;discards")) {
+						"--spring.cloud.stream.output-bindings=foo;bar;discards",
+						"--spring.cloud.stream.function.bindings.foo-out-0=foo",
+						"--spring.cloud.stream.function.bindings.bar-out-0=bar",
+						"--spring.cloud.stream.function.bindings.discards-out-0=discards")) {
 
 			InputDestination processorInput = context.getBean(InputDestination.class);
 

--- a/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
+++ b/applications/sink/router-sink/src/test/java/org/springframework/cloud/stream/app/sink/router/RouterSinkIntegrationTests.java
@@ -40,7 +40,6 @@ public class RouterSinkIntegrationTests {
 				.web(WebApplicationType.NONE)
 				.run("--spring.cloud.function.definition=routerSinkConsumer",
 						"--spring.cloud.stream.output-bindings=baz",
-						"--spring.cloud.stream.function.bindings.baz-out-0=baz",
 						"--router.resolutionRequired=true")) {
 
 			InputDestination processorInput = context.getBean(InputDestination.class);
@@ -130,10 +129,7 @@ public class RouterSinkIntegrationTests {
 						"--router.expression=headers['route']",
 						"--router.defaultOutputBinding=discards",
 						"--router.destinationMappings=foo=foo \n bar=bar",
-						"--spring.cloud.stream.output-bindings=foo;bar;discards",
-						"--spring.cloud.stream.function.bindings.foo-out-0=foo",
-						"--spring.cloud.stream.function.bindings.bar-out-0=bar",
-						"--spring.cloud.stream.function.bindings.discards-out-0=discards")) {
+						"--spring.cloud.stream.output-bindings=foo;bar;discards")) {
 
 			InputDestination processorInput = context.getBean(InputDestination.class);
 

--- a/applications/sink/router-sink/src/test/resources/routertest.groovy
+++ b/applications/sink/router-sink/src/test/resources/routertest.groovy
@@ -2,5 +2,5 @@ if ('foo' == headers.route) {
     return "$foo" // mapped to baz in 'variables'
 }
 else {
-    return "$bar" // mapped to qux in properties file.
+    return "$bar" // mapped to qux in properties file
 }

--- a/applications/sink/router-sink/src/test/resources/routertest.groovy
+++ b/applications/sink/router-sink/src/test/resources/routertest.groovy
@@ -2,5 +2,5 @@ if ('foo' == headers.route) {
     return "$foo" // mapped to baz in 'variables'
 }
 else {
-    return "$bar" // mapped to qux in properties file
+    return "$bar" // mapped to qux in properties file.
 }

--- a/applications/sink/router-sink/src/test/resources/routertest.groovy
+++ b/applications/sink/router-sink/src/test/resources/routertest.groovy
@@ -1,5 +1,6 @@
-if (headers.route.equals('foo')) {
+if ('foo' == headers.route) {
     return "$foo" // mapped to baz in 'variables'
-} else {
+}
+else {
     return "$bar" // mapped to qux in properties file
 }

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -43,7 +43,7 @@
         <spring-cloud.version>2022.0.0</spring-cloud.version>
         <spring-cloud-starters.version>4.0.0</spring-cloud-starters.version>
         <spring-cloud-function.version>4.0.0</spring-cloud-function.version>
-        <spring-cloud-stream-dependencies.version>4.0.0</spring-cloud-stream-dependencies.version>
+        <spring-cloud-stream-dependencies.version>4.0.1-SNAPSHOT</spring-cloud-stream-dependencies.version>
         <spring-cloud-stream.version>4.0.0</spring-cloud-stream.version>
         <test-containers.version>1.17.6</test-containers.version>
         <mockserver.version>5.13.2</mockserver.version>

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -44,7 +44,7 @@
         <spring-cloud-starters.version>4.0.0</spring-cloud-starters.version>
         <spring-cloud-function.version>4.0.0</spring-cloud-function.version>
         <spring-cloud-stream-dependencies.version>4.0.1-SNAPSHOT</spring-cloud-stream-dependencies.version>
-        <spring-cloud-stream.version>4.0.1-SNAPSHOT</spring-cloud-stream.version>
+        <spring-cloud-stream.version>4.0.0</spring-cloud-stream.version>
         <test-containers.version>1.17.6</test-containers.version>
         <mockserver.version>5.13.2</mockserver.version>
 

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -44,7 +44,7 @@
         <spring-cloud-starters.version>4.0.0</spring-cloud-starters.version>
         <spring-cloud-function.version>4.0.0</spring-cloud-function.version>
         <spring-cloud-stream-dependencies.version>4.0.1-SNAPSHOT</spring-cloud-stream-dependencies.version>
-        <spring-cloud-stream.version>4.0.0</spring-cloud-stream.version>
+        <spring-cloud-stream.version>4.0.1-SNAPSHOT</spring-cloud-stream.version>
         <test-containers.version>1.17.6</test-containers.version>
         <mockserver.version>5.13.2</mockserver.version>
 


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/330

The `BinderAwareChannelResolver` is removed now from SCST.

* Rework the router sink application logic to rely on a `StreamBridge` from SCST. For the reason introduce a simple `BindingChannelResolver` which creates path-through `MessageChannel` proxy for `streamBridge.send()` API and caches such a channel for future calls. This way the router logic from Spring Integration remains the same: we resolve a key into specific `MessageChannel`.
* Use `resolutionRequired` in this `BindingChannelResolver` to determine if binding has been declared explicitly for the application.
* Rename `defaultOutputChannel` configuration property into `defaultOutputBinding` since router sink does not rely on channel anymore, but rather on bindings
* Some code clean up in the `RouterSinkConfiguration` and `README.adoc`