### PR TITLE
Remove invalid config props references

### DIFF
--- a/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
+++ b/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
@@ -1,5 +1,4 @@
 configuration-properties.classes=org.springframework.cloud.fn.aggregator.AggregatorFunctionProperties,\
   org.springframework.boot.autoconfigure.mongo.MongoProperties,\
-  org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoProperties,\
   org.springframework.boot.autoconfigure.data.redis.RedisProperties,\
   org.springframework.boot.autoconfigure.jdbc.DataSourceProperties

--- a/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata.properties
+++ b/applications/processor/aggregator-processor/src/main/resources/META-INF/dataflow-configuration-metadata.properties
@@ -1,5 +1,4 @@
 configuration-properties.classes=org.springframework.cloud.fn.aggregator.AggregatorFunctionProperties,\
   org.springframework.boot.autoconfigure.mongo.MongoProperties,\
-  org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoProperties,\
   org.springframework.boot.autoconfigure.data.redis.RedisProperties,\
   org.springframework.boot.autoconfigure.jdbc.DataSourceProperties

--- a/applications/sink/elasticsearch-sink/README.adoc
+++ b/applications/sink/elasticsearch-sink/README.adoc
@@ -15,13 +15,28 @@ This is provided mainly for direct invocation of the consumer.
 The **$$Elasticsearch$$** $$sink$$ has the following options:
 
 //tag::configuration-properties[]
-$$elasticsearch.consumer.async$$:: $$Indicates whether the indexing operation is async or not. By default indexing is done synchronously.$$ *($$Boolean$$, default: `$$false$$`)*
-$$elasticsearch.consumer.batch-size$$:: $$Number of items to index for each request. It defaults to 1. For values greater than 1 bulk indexing API will be used.$$ *($$Integer$$, default: `$$1$$`)*
-$$elasticsearch.consumer.group-timeout$$:: $$Timeout in milliseconds after which message group is flushed when bulk indexing is active. It defaults to -1, meaning no automatic flush of idle message groups occurs.$$ *($$Long$$, default: `$$-1$$`)*
-$$elasticsearch.consumer.id$$:: $$The id of the document to index. If set, the INDEX_ID header value overrides this property on a per message basis.$$ *($$Expression$$, default: `$$<none>$$`)*
-$$elasticsearch.consumer.index$$:: $$Name of the index. If set, the INDEX_NAME header value overrides this property on a per message basis.$$ *($$String$$, default: `$$<none>$$`)*
-$$elasticsearch.consumer.routing$$:: $$Indicates the shard to route to. If not provided, Elasticsearch will default to a hash of the document id.$$ *($$String$$, default: `$$<none>$$`)*
-$$elasticsearch.consumer.timeout-seconds$$:: $$Timeout for the shard to be available. If not set, it defaults to 1 minute set by the Elasticsearch client.$$ *($$Long$$, default: `$$0$$`)*
+Properties grouped by prefix:
+
+
+=== elasticsearch.consumer
+
+$$async$$:: $$Indicates whether the indexing operation is async or not. By default indexing is done synchronously.$$ *($$Boolean$$, default: `$$false$$`)*
+$$batch-size$$:: $$Number of items to index for each request. It defaults to 1. For values greater than 1 bulk indexing API will be used.$$ *($$Integer$$, default: `$$1$$`)*
+$$group-timeout$$:: $$Timeout in milliseconds after which message group is flushed when bulk indexing is active. It defaults to -1, meaning no automatic flush of idle message groups occurs.$$ *($$Long$$, default: `$$-1$$`)*
+$$id$$:: $$The id of the document to index. If set, the INDEX_ID header value overrides this property on a per message basis.$$ *($$Expression$$, default: `$$<none>$$`)*
+$$index$$:: $$Name of the index. If set, the INDEX_NAME header value overrides this property on a per message basis.$$ *($$String$$, default: `$$<none>$$`)*
+$$routing$$:: $$Indicates the shard to route to. If not provided, Elasticsearch will default to a hash of the document id.$$ *($$String$$, default: `$$<none>$$`)*
+$$timeout-seconds$$:: $$Timeout for the shard to be available. If not set, it defaults to 1 minute set by the Elasticsearch client.$$ *($$Long$$, default: `$$0$$`)*
+
+=== spring.elasticsearch
+
+$$connection-timeout$$:: $$Connection timeout used when communicating with Elasticsearch.$$ *($$Duration$$, default: `$$1s$$`)*
+$$password$$:: $$Password for authentication with Elasticsearch.$$ *($$String$$, default: `$$<none>$$`)*
+$$path-prefix$$:: $$Prefix added to the path of every request sent to Elasticsearch.$$ *($$String$$, default: `$$<none>$$`)*
+$$socket-keep-alive$$:: $$Whether to enable socket keep alive between client and Elasticsearch.$$ *($$Boolean$$, default: `$$false$$`)*
+$$socket-timeout$$:: $$Socket timeout used when communicating with Elasticsearch.$$ *($$Duration$$, default: `$$30s$$`)*
+$$uris$$:: $$Comma-separated list of the Elasticsearch instances to use.$$ *($$List<String>$$, default: `$$[http://localhost:9200]$$`)*
+$$username$$:: $$Username for authentication with Elasticsearch.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 == Examples of running this sink

--- a/applications/sink/elasticsearch-sink/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
+++ b/applications/sink/elasticsearch-sink/src/main/resources/META-INF/dataflow-configuration-metadata-whitelist.properties
@@ -1,2 +1,2 @@
 configuration-properties.classes=org.springframework.cloud.fn.consumer.elasticsearch.ElasticsearchConsumerProperties, \
-  org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientProperties
+  org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchProperties

--- a/applications/sink/elasticsearch-sink/src/main/resources/META-INF/dataflow-configuration-metadata.properties
+++ b/applications/sink/elasticsearch-sink/src/main/resources/META-INF/dataflow-configuration-metadata.properties
@@ -1,2 +1,2 @@
 configuration-properties.classes=org.springframework.cloud.fn.consumer.elasticsearch.ElasticsearchConsumerProperties, \
-  org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientProperties
+  org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchProperties

--- a/applications/source/mail-source/README.adoc
+++ b/applications/source/mail-source/README.adoc
@@ -8,12 +8,12 @@ A source application that listens for Emails and emits the message body as a mes
 The **$$mail$$** $$source$$ has the following options:
 
 //tag::configuration-properties[]
-$$mail.supplier.charset$$:: $$The charset for byte[] mail-to-string transformation.$$ *($$String$$, default: `$$<none>$$`)*
-$$mail.supplier.delete$$:: $$Set to true to delete email after download.$$ *($$Boolean$$, default: `$$<none>$$`)*
-$$mail.supplier.expression$$:: $$Configure a SpEL expression to select messages.$$ *($$String$$, default: `$$<none>$$`)*
-$$mail.supplier.idle-imap$$:: $$Set to true to use IdleImap Configuration.$$ *($$Boolean$$, default: `$$<none>$$`)*
+$$mail.supplier.charset$$:: $$The charset for byte[] mail-to-string transformation.$$ *($$String$$, default: `$$UTF-8$$`)*
+$$mail.supplier.delete$$:: $$Set to true to delete email after download.$$ *($$Boolean$$, default: `$$false$$`)*
+$$mail.supplier.expression$$:: $$Configure a SpEL expression to select messages.$$ *($$String$$, default: `$$true$$`)*
+$$mail.supplier.idle-imap$$:: $$Set to true to use IdleImap Configuration.$$ *($$Boolean$$, default: `$$false$$`)*
 $$mail.supplier.java-mail-properties$$:: $$JavaMail properties as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.$$ *($$Properties$$, default: `$$<none>$$`)*
-$$mail.supplier.mark-as-read$$:: $$Set to true to mark email as read.$$ *($$Boolean$$, default: `$$<none>$$`)*
+$$mail.supplier.mark-as-read$$:: $$Set to true to mark email as read.$$ *($$Boolean$$, default: `$$false$$`)*
 $$mail.supplier.url$$:: $$Mail connection URL for connection to Mail server e.g. 'imaps://username:password@imap.server.com:993/Inbox'.$$ *($$URLName$$, default: `$$<none>$$`)*
 $$mail.supplier.user-flag$$:: $$The flag to mark messages when the server does not support \Recent.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]


### PR DESCRIPTION
* `sink/elasticsearch-sink`: SB3 now uses Elastic Java client instead of Elastic High-Level REST client, therefore replace `ElasticsearchRestClientProperties` w/ `ElasticsearchProperties.

* `processor/aggregator-processor`: SB3 has removed Embedded Mongo support, therefore remove the corresponding EmbeddedMongoProperties.

Fixes #435