### PR TITLE
Fix ElasticsearchSink index name header

### DIFF
--- a/applications/sink/elasticsearch-sink/src/test/resources/logback-test.xml
+++ b/applications/sink/elasticsearch-sink/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="org.testcontainers" level="ERROR"/>
+    <logger name="com.github.dockerjava" level="ERROR"/>
+	<logger name="org.springframework.cloud" level="INFO"/>
+</configuration>

--- a/functions/consumer/elasticsearch-consumer/src/main/java/org/springframework/cloud/fn/consumer/elasticsearch/ElasticsearchConsumerConfiguration.java
+++ b/functions/consumer/elasticsearch-consumer/src/main/java/org/springframework/cloud/fn/consumer/elasticsearch/ElasticsearchConsumerConfiguration.java
@@ -47,7 +47,6 @@ import org.springframework.integration.aggregator.MessageCountReleaseStrategy;
 import org.springframework.integration.config.AggregatorFactoryBean;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
-import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
@@ -126,7 +125,7 @@ public class ElasticsearchConsumerConfiguration {
 	) {
 
 		final IntegrationFlowBuilder builder =
-			IntegrationFlows.from(Consumer.class, gateway -> gateway.beanName("elasticsearchConsumer"));
+			IntegrationFlow.from(MessageConsumer.class, gateway -> gateway.beanName("elasticsearchConsumer"));
 		if (properties.getBatchSize() > 1) {
 			builder.handle(aggregator);
 		}
@@ -297,4 +296,9 @@ public class ElasticsearchConsumerConfiguration {
 			return message;
 		}
 	}
+
+	private interface MessageConsumer extends Consumer<Message<?>> {
+
+	}
+
 }


### PR DESCRIPTION
- Use `Consumer<Message<?>>` on IntegrationFlow rather than `Consumer`

Fixes #440