### PR TITLE
GH-441: Add `JsonBytesToMap` function

### DIFF
--- a/applications/processor/aggregator-processor/README.adoc
+++ b/applications/processor/aggregator-processor/README.adoc
@@ -9,6 +9,10 @@ Change kafka to rabbit if you want to run it against RabbitMQ.
 
 === Payload
 
+If an input payload is a `byte[]` and content-type header is a JSON, then `JsonBytesToMap` function tries to deserialize this payload to a `Map` for better data representation on the output of the aggregator function.
+Also, such a `Map` data representation makes it easy to access to the payload content from SpEL expressions mentioned below.
+Otherwise, the input payload is left as is -  and it is the target application configuration to convert it into a desired form.
+
 == Options
 
 //tag::configuration-properties[]

--- a/applications/processor/aggregator-processor/README.adoc
+++ b/applications/processor/aggregator-processor/README.adoc
@@ -11,7 +11,7 @@ Change kafka to rabbit if you want to run it against RabbitMQ.
 
 If an input payload is a `byte[]` and content-type header is a JSON, then `JsonBytesToMap` function tries to deserialize this payload to a `Map` for better data representation on the output of the aggregator function.
 Also, such a `Map` data representation makes it easy to access to the payload content from SpEL expressions mentioned below.
-Otherwise, the input payload is left as is -  and it is the target application configuration to convert it into a desired form.
+Otherwise(including a deserialization error), the input payload is left as is - and it is the target application configuration to convert it into a desired form.
 
 == Options
 

--- a/applications/processor/aggregator-processor/pom.xml
+++ b/applications/processor/aggregator-processor/pom.xml
@@ -32,7 +32,7 @@
                         <type>processor</type>
                         <version>${project.version}</version>
                         <configClass>org.springframework.cloud.fn.aggregator.AggregatorFunctionConfiguration.class</configClass>
-                        <functionDefinition>aggregatorFunction</functionDefinition>
+                        <functionDefinition>jsonBytesToMap|aggregatorFunction</functionDefinition>
                         <maven>
                             <dependencies>
                                 <dependency>

--- a/applications/processor/aggregator-processor/src/test/java/org/springframework/cloud/fn/aggregator/AggregatorProcessorTests.java
+++ b/applications/processor/aggregator-processor/src/test/java/org/springframework/cloud/fn/aggregator/AggregatorProcessorTests.java
@@ -75,7 +75,7 @@ public class AggregatorProcessorTests {
 					objectMapper.readValue(receive.getPayload(),
 							objectMapper.constructType(new TypeReference<List<Person>>() { }));
 
-			assertThat(result).hasSize(2).contains(person1, person2);
+			assertThat(result).containsExactly(person1, person2);
 		}
 	}
 

--- a/functions/function/aggregator-function/pom.xml
+++ b/functions/function/aggregator-function/pom.xml
@@ -16,6 +16,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.cloud.fn</groupId>
+            <artifactId>payload-converter-function</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-core</artifactId>
         </dependency>

--- a/functions/function/payload-converter-function/src/main/java/functions/JsonBytesToMap.java
+++ b/functions/function/payload-converter-function/src/main/java/functions/JsonBytesToMap.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeTypeUtils;
+
+/**
+ * The {@link Function} to deserialize {@code byte[]} payload into a Map
+ * if {@link MessageHeaders#CONTENT_TYPE} header is JSON.
+ * Otherwise, the message is returned as is.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.0
+ */
+public class JsonBytesToMap implements Function<Message<?>, Message<?>> {
+
+	private final ObjectMapper objectMapper;
+
+	public JsonBytesToMap(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public Message<?> apply(Message<?> message) {
+		if (message.getPayload() instanceof byte[] payload) {
+			MessageHeaders headers = message.getHeaders();
+			String contentType =
+					headers.containsKey(MessageHeaders.CONTENT_TYPE)
+							? headers.get(MessageHeaders.CONTENT_TYPE).toString()
+							: MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+			if (contentType.contains("json")) {
+				message = MessageBuilder.withPayload(payloadToMapIfCan(payload))
+						.copyHeaders(message.getHeaders())
+						.build();
+			}
+		}
+
+		return message;
+	}
+
+	private Object payloadToMapIfCan(byte[] payload) {
+		try {
+			return this.objectMapper.readValue(payload, Map.class);
+		}
+		catch (IOException ex) {
+			// Was not able to construct the map from byte[] -- returning as is
+			return payload;
+		}
+	}
+
+}

--- a/functions/function/payload-converter-function/src/main/java/functions/JsonBytesToMap.java
+++ b/functions/function/payload-converter-function/src/main/java/functions/JsonBytesToMap.java
@@ -17,7 +17,6 @@
 package functions;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -34,7 +33,6 @@ import org.springframework.util.MimeTypeUtils;
  * Otherwise, the message is returned as is.
  *
  * @author Artem Bilan
- *
  * @since 4.0
  */
 public class JsonBytesToMap implements Function<Message<?>, Message<?>> {

--- a/functions/function/payload-converter-function/src/main/java/functions/JsonBytesToMap.java
+++ b/functions/function/payload-converter-function/src/main/java/functions/JsonBytesToMap.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.core.log.LogAccessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
@@ -33,9 +34,12 @@ import org.springframework.util.MimeTypeUtils;
  * Otherwise, the message is returned as is.
  *
  * @author Artem Bilan
+ *
  * @since 4.0
  */
 public class JsonBytesToMap implements Function<Message<?>, Message<?>> {
+
+	private static final LogAccessor logger = new LogAccessor(JsonBytesToMap.class);
 
 	private final ObjectMapper objectMapper;
 
@@ -67,6 +71,7 @@ public class JsonBytesToMap implements Function<Message<?>, Message<?>> {
 			return this.objectMapper.readValue(payload, Map.class);
 		}
 		catch (IOException ex) {
+			logger.trace(ex, "Cannot deserialize to Map");
 			// Was not able to construct the map from byte[] -- returning as is
 			return payload;
 		}


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/441

* Introduce a `JsonBytesToMap` as a part of a `payload-converter-function` module which is auto-discovered by Spring Cloud Function scanning algorithm - the `functions` package.
* Add a `payload-converter-function` as dependency into an `aggregator-function`
* Compose `jsonBytesToMap|aggregatorFunction` for the `aggregator-processor`
* Verify a `JsonBytesToMap` function in action with an `AggregatorProcessorTests`
* Mentioned such a payload conversion in the `aggregator-processor` README