### PR TITLE
[DO NOT MERGE YET] app auto-conf support

### DIFF
--- a/applications/source/debezium-source/pom.xml
+++ b/applications/source/debezium-source/pom.xml
@@ -150,8 +150,7 @@
 						<name>debezium</name>
 						<type>source</type>
 						<version>${project.version}</version>
-						<configClass>org.springframework.cloud.fn.supplier.debezium.DebeziumReactiveConsumerConfiguration.class
-						</configClass>
+						<configClass>AUTOCONFIGURATION</configClass>
 						<functionDefinition>debeziumSupplier</functionDefinition>
 
 						<properties>

--- a/applications/source/debezium-source/src/test/java/org/springframework/cloud/stream/app/source/debezium/databases/DebeziumDatabasesIntegrationTest.java
+++ b/applications/source/debezium-source/src/test/java/org/springframework/cloud/stream/app/source/debezium/databases/DebeziumDatabasesIntegrationTest.java
@@ -37,12 +37,10 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.fn.supplier.debezium.DebeziumReactiveConsumerConfiguration;
 import org.springframework.cloud.stream.app.source.debezium.integration.DebeziumTestUtils;
 import org.springframework.cloud.stream.binder.test.OutputDestination;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
 import org.springframework.util.CollectionUtils;
 
@@ -244,7 +242,6 @@ public class DebeziumDatabasesIntegrationTest {
 
 	@SpringBootConfiguration
 	@EnableAutoConfiguration(exclude = { MongoAutoConfiguration.class, DataSourceAutoConfiguration.class })
-	@Import(DebeziumReactiveConsumerConfiguration.class)
 	public static class TestApplication {
 	}
 

--- a/applications/source/debezium-source/src/test/java/org/springframework/cloud/stream/app/source/debezium/integration/TestDebeziumSourceApplication.java
+++ b/applications/source/debezium-source/src/test/java/org/springframework/cloud/stream/app/source/debezium/integration/TestDebeziumSourceApplication.java
@@ -25,9 +25,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.fn.supplier.debezium.DebeziumReactiveConsumerConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -36,7 +34,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
  */
 @SpringBootConfiguration
 @EnableAutoConfiguration(exclude = {MongoAutoConfiguration.class})
-@Import(DebeziumReactiveConsumerConfiguration.class)
 public class TestDebeziumSourceApplication {
 
 	@Bean

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -20,9 +20,9 @@
         <java-functions.version>4.0.0-SNAPSHOT</java-functions.version>
         <apps.base-image>springcloud/baseimage:1.0.3</apps.base-image>
 		<prometheus-rsocket.version>1.5.0</prometheus-rsocket.version>
-        <spring-cloud-dataflow-apps-generator-plugin.version>1.0.7</spring-cloud-dataflow-apps-generator-plugin.version>
-        <spring-cloud-dataflow-apps-docs-plugin.version>1.0.7</spring-cloud-dataflow-apps-docs-plugin.version>
-        <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.7</spring-cloud-dataflow-apps-metadata-plugin.version>
+        <spring-cloud-dataflow-apps-generator-plugin.version>1.0.8-SNAPSHOT</spring-cloud-dataflow-apps-generator-plugin.version>
+        <spring-cloud-dataflow-apps-docs-plugin.version>1.0.8-SNAPSHOT</spring-cloud-dataflow-apps-docs-plugin.version>
+        <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.8-SNAPSHOT</spring-cloud-dataflow-apps-metadata-plugin.version>
         <java-cfenv-boot.version>2.4.0</java-cfenv-boot.version>
     </properties>
 


### PR DESCRIPTION
Provide auto-config application support. 
Requires `org.springframework.cloud:spring-cloud-dataflow-apps-generator-plugin` version >= 1.0.8-SNAPSHOT.
