### PR TITLE
GH-275: Mention `ComponentCustomizer` in READMEs

### DIFF
--- a/functions/consumer/file-consumer/README.adoc
+++ b/functions/consumer/file-consumer/README.adoc
@@ -17,6 +17,8 @@ All configuration properties are prefixed with `file.consumer`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/consumer/file/FileConsumerProperties.java[FileConsumerProperties].
 
+A `ComponentCustomizer<FileWritingMessageHandler>` bean can be added in the target project to provide any custom options for the `FileWritingMessageHandler` configuration used by the `fileConsumer`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/consumer/file[test suite] for the various ways, this consumer is used.

--- a/functions/consumer/ftp-consumer/README.adoc
+++ b/functions/consumer/ftp-consumer/README.adoc
@@ -17,6 +17,8 @@ All configuration properties are prefixed with `ftp.consumer`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/consumer/ftp/FtpConsumerProperties.java[FtpConsumerProperties].
 
+A `ComponentCustomizer<FtpMessageHandlerSpec>` bean can be added in the target project to provide any custom options for the `FtpMessageHandlerSpec` configuration used by the `ftpConsumer`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/consumer/ftp[test suite] for the various ways, this consumer is used.

--- a/functions/consumer/mongodb-consumer/README.adoc
+++ b/functions/consumer/mongodb-consumer/README.adoc
@@ -20,6 +20,8 @@ All configuration properties are prefixed with `mongodb.consumer`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/consumer/mongo/MongoDBConsumerProperties.java[MongoDBConsumerProperties].
 
+A `ComponentCustomizer<ReactiveMongoDbStoringMessageHandler>` bean can be added in the target project to provide any custom options for the `ReactiveMongoDbStoringMessageHandler` configuration used by the `mongodbConsumer`.
+
 ## Examples
 
 See this link:src/test/java/org/springframework/cloud/fn/consumer/mongo/MongoDBConsumerApplicationTests.java[test suite] for the various ways, this consumer is used.

--- a/functions/consumer/mqtt-consumer/README.adoc
+++ b/functions/consumer/mqtt-consumer/README.adoc
@@ -16,6 +16,8 @@ All configuration properties are prefixed with `mqtt.consumer`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/consumer/mqtt/MqttConsumerProperties.java[MqttConsumerProperties].
 
+A `ComponentCustomizer<MongoDbMessageSource>` bean can be added in the target project to provide any custom options for the `MongoDbMessageSource` configuration used by the `mongodbSupplier`.
+
 ## SSL Configuration
 
 The MQTT Paho client can accept an SSL configuration via `MqttConnectOptions.setSSLProperties()`.

--- a/functions/consumer/rabbit-consumer/README.adoc
+++ b/functions/consumer/rabbit-consumer/README.adoc
@@ -16,6 +16,8 @@ All configuration properties are prefixed with `rabbit`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/consumer/rabbit/RabbitConsumerProperties.java[RabbitConsumerProperties].
 
+A `ComponentCustomizer<AmqpOutboundChannelAdapterSpec>` bean can be added in the target project to provide any custom options for the `AmqpOutboundChannelAdapterSpec` configuration used by the `rabbitConsumer`.
+
 ## Tests
 
 

--- a/functions/consumer/sftp-consumer/README.adoc
+++ b/functions/consumer/sftp-consumer/README.adoc
@@ -16,6 +16,8 @@ All configuration properties are prefixed with `sftp.consumer`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/consumer/sftp/SFTPConsumerProperties.java[SftpConsumerProperties].
 
+A `ComponentCustomizer<SftpMessageHandlerSpec>` bean can be added in the target project to provide any custom options for the `SftpMessageHandlerSpec` configuration used by the `sftpConsumer`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/consumer/sftp[test suite] for the various ways, this consumer is used.

--- a/functions/function/aggregator-function/README.adoc
+++ b/functions/function/aggregator-function/README.adoc
@@ -16,6 +16,8 @@ Once injected, you can use the `apply` method of the `Function` to invoke it and
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionProperties.java[AggregatorFunctionProperties.java]
 
+A `ComponentCustomizer<AggregatorFactoryBean>` bean can be added in the target project to provide any custom options for the `AggregatorFactoryBean` configuration used by the `aggregatorFunction` definition.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/aggregator/AggregatorFunctionApplicationTests.java[test suite] for examples of how this function is used.

--- a/functions/supplier/file-supplier/README.adoc
+++ b/functions/supplier/file-supplier/README.adoc
@@ -26,6 +26,8 @@ There are also properties that need to be used with the prefix `file.consumer`.
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/file/FileSupplierProperties.java[FileSupplierProperties].
 See link:src/main/java/org/springframework/cloud/fn/supplier/file/FileConsumerProperties.java[this] also.
 
+A `ComponentCustomizer<FileInboundChannelAdapterSpec>` bean can be added in the target project to provide any custom options for the `FileInboundChannelAdapterSpec` configuration used by the `fileSupplier`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/file[test suite] for the various ways, this supplier is used.

--- a/functions/supplier/ftp-supplier/README.adoc
+++ b/functions/supplier/ftp-supplier/README.adoc
@@ -26,6 +26,8 @@ There are also properties that need to be used with the prefix `file.consumer`.
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/ftp/FtpSupplierProperties.java[FtpSupplierProperties].
 See link:src/main/java/org/springframework/cloud/fn/supplier/file/FileConsumerProperties.java[this] also.
 
+A `ComponentCustomizer<FtpInboundChannelAdapterSpec>` bean can be added in the target project to provide any custom options for the `FtpInboundChannelAdapterSpec` configuration used by the `ftpSupplier`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/ftp/FtpSupplierTests.java[test suite] for the various ways, this supplier is used.

--- a/functions/supplier/jdbc-supplier/README.adoc
+++ b/functions/supplier/jdbc-supplier/README.adoc
@@ -25,6 +25,8 @@ All configuration properties are prefixed with `jdbc.supplier`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/jdbc/JdbcSupplierProperties.java[JdbcSupplierProperties]
 
+A `ComponentCustomizer<JdbcPollingChannelAdapter>` bean can be added in the target project to provide any custom options for the `JdbcPollingChannelAdapter` configuration used by the `jdbcSupplier`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/jdbc[test suite] for the various ways, this supplier is used.

--- a/functions/supplier/jms-supplier/README.adoc
+++ b/functions/supplier/jms-supplier/README.adoc
@@ -24,6 +24,8 @@ All configuration properties are prefixed with `jms`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/jms/JmsSupplierProperties.java[JmsSupplierProperties].
 
+A `ComponentCustomizer<JmsMessageDrivenChannelAdapterSpec<?>>` bean can be added in the target project to provide any custom options for the `JmsMessageDrivenChannelAdapterSpec` configuration used by the `jmsSupplier`.
+
 ## Examples
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/jms/[test suite] for the various ways, this supplier is used.

--- a/functions/supplier/mail-supplier/README.adoc
+++ b/functions/supplier/mail-supplier/README.adoc
@@ -25,6 +25,8 @@ All configuration properties are prefixed with `mail.supplier`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/mail/MailSupplierProperties.java[MailSupplierProperties].
 
+A `ComponentCustomizer<MailInboundChannelAdapterSpec<?, ?>>` (or `ComponentCustomizer<ImapIdleChannelAdapterSpec>` when `mail.supplier.idle-imap = true`) bean can be added in the target project to provide any custom options for the `MailInboundChannelAdapterSpec` (or `ImapIdleChannelAdapterSpec`, respectively) configuration used by the `mailSupplier`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/mail[test suite] for the various ways, this supplier is used.

--- a/functions/supplier/mongodb-supplier/README.adoc
+++ b/functions/supplier/mongodb-supplier/README.adoc
@@ -28,6 +28,8 @@ For more information on the various options available, please see link:src/main/
 The `queryExpression` and `updateExpression` options may use Spring Data MongoDB query DSL from the `org.springframework.data.mongodb.core.query`, such as `Query` and `Update` factories respectively.
 The `updateExpression` is optional and ca use an item from query result as a root evaluation object to extract some values to update from just fetched data.
 
+A `ComponentCustomizer<MqttPahoMessageHandler>` bean can be added in the target project to provide any custom options for the `MqttPahoMessageHandler` configuration used by the `mqttConsumer`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/mongo/MongodbSupplierApplicationTests.java[test suite] for the various ways, this supplier is used.

--- a/functions/supplier/mqtt-supplier/README.adoc
+++ b/functions/supplier/mqtt-supplier/README.adoc
@@ -24,6 +24,8 @@ All configuration properties are prefixed with `mqtt.supplier` and `mqtt`.
 
 For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/mqtt/MqttSupplierProperties.java[MqttSupplierProperties].
 
+A `ComponentCustomizer<MqttPahoMessageDrivenChannelAdapter>` bean can be added in the target project to provide any custom options for the `MqttPahoMessageDrivenChannelAdapter` configuration used by the `mqttSupplier`.
+
 ## SSL Configuration
 
 The MQTT Paho client can accept an SSL configuration via `MqttConnectOptions.setSSLProperties()`.

--- a/functions/supplier/rabbit-supplier/README.adoc
+++ b/functions/supplier/rabbit-supplier/README.adoc
@@ -1,0 +1,34 @@
+# RabbitMQ Supplier
+
+This module provides an RabbitMQ supplier that can be reused and composed in other applications.
+The `Supplier` uses the RabbitMQ support provided by Spring Integration.
+The `rabbitSupplier` is implemented as a `java.util.function.Supplier`.
+This supplier gives you a reactive stream of files from the provided directory as the supplier has a signature of `Supplier<Flux<Message<?>>>`.
+Users have to subscribe to this `Flux` and receive the data.
+
+## Beans for injection
+
+You can import the `RabbitSupplierConfiguration` in the application and then inject the following bean.
+
+`rabbitSupplier`
+
+You need to inject this as `Supplier<Flux<Message<?>>>`.
+
+You can use `rabbitSupplier` as a qualifier when injecting.
+
+Once injected, you can use the `get` method of the `Supplier` to invoke it and then subscribe to the returned `Flux`.
+
+## Configuration Options
+
+All configuration properties are prefixed with `rabbit.supplier`.
+
+For more information on the various options available, please see link:src/main/java/org/springframework/cloud/fn/supplier/rabbit/RabbitSupplierProperties.java[RabbitSupplierProperties].
+Also see an auto-configuration for RabbitMQ connection and listener container options.
+
+A `ComponentCustomizer<AmqpInboundChannelAdapterSMLCSpec>` bean can be added in the target project to provide any custom options for the `AmqpInboundChannelAdapterSMLCSpec` configuration used by the `rabbitSupplier`.
+
+## Tests
+
+## Other usage
+
+See this https://github.com/spring-cloud/stream-applications/blob/master/applications/source/rabbit-source/README.adoc[README] where this supplier is used to create a Spring Cloud Stream application where it makes a RabbitMQ Source.

--- a/functions/supplier/s3-supplier/README.adoc
+++ b/functions/supplier/s3-supplier/README.adoc
@@ -27,6 +27,8 @@ For more information on the various options available, please see link:src/main/
 link:../../common/file-common/src/main/java/org/springframework/cloud/fn/common/file/FileConsumerProperties.java[FileConsumerProperties], and
 link:../../common/aws-s3-common/src/main/java/org/springframework/cloud/fn/common/aws/s3/AmazonS3Properties.java[AmazonS3Properties].
 
+A `ComponentCustomizer<S3InboundFileSynchronizingMessageSource>` bean can be added in the target project to provide any custom options for the `S3InboundFileSynchronizingMessageSource` configuration used by the `s3Supplier`.
+
 ## Tests
 
 See this link:src/test/java/org/springframework/cloud/fn/supplier/s3[test suite] for the various ways, this supplier is used.


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/stream-applications/issues/275

Many functions make use of `ComponentCustomizer` ot let end-user to provide any custom configuration for target component used by the function. First of all for use-case which are not covered by standard configuration properties and secondly for those options which cannot be represented as a configuration option.

* Add a sentence to READMEs of those functions which make use of `ComponentCustomizer` with an expected generic argument type
* Add README into `rabbit-supplier` where it is fully missed at the moment