### PR TITLE
Request to Remove Non-functional Link in README.doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,7 +74,7 @@ The following are the various components of this repository.
 |link:functions/consumer/rabbit-consumer/README.adoc[RabbitMQ]
 
 |link:functions/supplier/s3-supplier/README.adoc[AWS S3]
-|link:functions/function/tasklauncher-function/README.adoc[Task Launcher]
+|
 |link:functions/consumer/redis-consumer/README.adoc[Redis]
 
 |link:functions/supplier/sftp-supplier/README.adoc[SFTP]


### PR DESCRIPTION
I recently came across the "Task Launcher" link in the README.doc of your repository. Upon further inspection, I noticed that the link does not lead to a functioning page, and there doesn't appear to be any associated functionality.

Considering this, I kindly request that you consider removing the non-functional link from the README.doc to avoid any confusion for future visitors to your repository. 

Thank you for your attention to this matter, and please let me know if you have any questions or require any assistance.

Best regards, SeungJin Jeong.