### PR TITLE
Fix scope of function-test-support dependency

### DIFF
--- a/functions/consumer/ftp-consumer/pom.xml
+++ b/functions/consumer/ftp-consumer/pom.xml
@@ -27,6 +27,7 @@
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>function-test-support</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/functions/consumer/sftp-consumer/pom.xml
+++ b/functions/consumer/sftp-consumer/pom.xml
@@ -22,6 +22,7 @@
             <groupId>org.springframework.cloud.fn</groupId>
             <artifactId>function-test-support</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Fix scope of function-test-support dependency

I noticed unexpected logging behaviour when using `sftp-consumer` caused by the missing test scope of the `function-test-support` dependency.

Workaround:

```
    <dependency>
      <groupId>org.springframework.cloud.fn</groupId>
      <artifactId>sftp-consumer</artifactId>
      <version>4.0.1-SNAPSHOT</version>
      <exclusions>
        <exclusion>
          <groupId>org.springframework.cloud.fn</groupId>
          <artifactId>function-test-support</artifactId>
        </exclusion>
      </exclusions>
    </dependency>

```
