### PR TITLE
Add spring.binders for SCSt test binder

### DIFF
--- a/applications/stream-applications-core/stream-applications-security-common/src/test/resources/META-INF/spring.binders
+++ b/applications/stream-applications-core/stream-applications-security-common/src/test/resources/META-INF/spring.binders
@@ -1,0 +1,2 @@
+integration:\
+org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration


### PR DESCRIPTION
Works around issue in SCSt `4.1.2` where the spring.binders was removed from the 
`spring-cloud-stream-test-binder` module.

cc: @sobychacko