### PR TITLE
Add Micrometer tracing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,6 +148,14 @@ This will build and test / integration test all the modules.
 ./full-build-test.sh
 ....
 
+==== Boil the Ocean (sans tests)
+
+This will build all the modules (including apps) but skip tests.
+
+....
+./full-build-no-test.sh
+....
+
 ==== Core
 
 This will build the core functionality and all functions.

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <stream-apps-core.version>5.0.1-SNAPSHOT</stream-apps-core.version>
         <java-functions.version>5.0.1-SNAPSHOT</java-functions.version>
-		<prometheus-rsocket.version>1.5.2</prometheus-rsocket.version>
+        <prometheus-rsocket.version>2.0.0-M1</prometheus-rsocket.version>
         <spring-cloud-dataflow-apps-generator-plugin.version>1.0.14</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
@@ -144,12 +144,10 @@
                                     <!-- Disable all meter repositories by default.  -->
                                     <management.wavefront.metrics.export.enabled>false</management.wavefront.metrics.export.enabled>
                                     <management.influx.metrics.export.enabled>false</management.influx.metrics.export.enabled>
-									<management.datadog.metrics.export.enabled>false</management.datadog.metrics.export.enabled>
-									<management.prometheus.metrics.export.enabled>false</management.prometheus.metrics.export.enabled>
-									<!-- rsocket proxy still on SB2.7.x naming convention -->
-									<management.metrics.export.prometheus.rsocket.enabled>false</management.metrics.export.prometheus.rsocket.enabled>
-
-									<!-- Add SCDF stream metrics tags. -->
+                                    <management.datadog.metrics.export.enabled>false</management.datadog.metrics.export.enabled>
+                                    <management.prometheus.metrics.export.enabled>false</management.prometheus.metrics.export.enabled>
+                                    <management.prometheus.metrics.export.rsocket.enabled>false</management.prometheus.metrics.export.rsocket.enabled>
+                                    <!-- Add SCDF stream metrics tags. -->
                                     <management.metrics.tags.stream.name>"${spring.cloud.dataflow.stream.name:unknown}"</management.metrics.tags.stream.name>
                                     <management.metrics.tags.application.name>"${spring.cloud.dataflow.stream.app.label:unknown}"</management.metrics.tags.application.name>
                                     <management.metrics.tags.application.type>"${spring.cloud.dataflow.stream.app.type:unknown}"</management.metrics.tags.application.type>
@@ -167,6 +165,16 @@
                                 </metadata>
                                 <maven>
                                     <dependencyManagement>
+                                        <dependency>
+                                            <groupId>io.micrometer.prometheus</groupId>
+                                            <artifactId>prometheus-rsocket-spring</artifactId>
+                                            <version>${prometheus-rsocket.version}</version>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>io.micrometer.prometheus</groupId>
+                                            <artifactId>prometheus-rsocket-client</artifactId>
+                                            <version>${prometheus-rsocket.version}</version>
+                                        </dependency>
                                         <!-- Temporarily override SC-Fn dependency by giving it the highest precedence since 2020.0.5 release of spring-cloud will not take place until December -->
                                         <dependency>
                                             <groupId>org.springframework.cloud</groupId>
@@ -217,11 +225,14 @@
                                             <groupId>io.micrometer</groupId>
                                             <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
                                         </dependency>
-										<dependency>
-											<groupId>io.micrometer.prometheus</groupId>
-											<artifactId>prometheus-rsocket-spring</artifactId>
-											<version>${prometheus-rsocket.version}</version>
-										</dependency>
+                                        <dependency>
+                                            <groupId>io.micrometer.prometheus</groupId>
+                                            <artifactId>prometheus-rsocket-spring</artifactId>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>io.micrometer.prometheus</groupId>
+                                            <artifactId>prometheus-rsocket-client</artifactId>
+                                        </dependency>
                                         <dependency>
                                             <groupId>io.micrometer</groupId>
                                             <artifactId>micrometer-registry-wavefront</artifactId>

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -170,11 +170,6 @@
                                             <artifactId>prometheus-rsocket-spring</artifactId>
                                             <version>${prometheus-rsocket.version}</version>
                                         </dependency>
-                                        <dependency>
-                                            <groupId>io.micrometer.prometheus</groupId>
-                                            <artifactId>prometheus-rsocket-client</artifactId>
-                                            <version>${prometheus-rsocket.version}</version>
-                                        </dependency>
                                         <!-- Temporarily override SC-Fn dependency by giving it the highest precedence since 2020.0.5 release of spring-cloud will not take place until December -->
                                         <dependency>
                                             <groupId>org.springframework.cloud</groupId>
@@ -228,10 +223,6 @@
                                         <dependency>
                                             <groupId>io.micrometer.prometheus</groupId>
                                             <artifactId>prometheus-rsocket-spring</artifactId>
-                                        </dependency>
-                                        <dependency>
-                                            <groupId>io.micrometer.prometheus</groupId>
-                                            <artifactId>prometheus-rsocket-client</artifactId>
                                         </dependency>
                                         <dependency>
                                             <groupId>io.micrometer</groupId>

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -155,11 +155,12 @@
                                     <management.metrics.tags.application.type>"${spring.cloud.dataflow.stream.app.type:unknown}"</management.metrics.tags.application.type>
                                     <management.metrics.tags.instance.index>"${spring.cloud.stream.instanceIndex:0}"</management.metrics.tags.instance.index>
                                     <management.metrics.tags.application.guid>"${spring.cloud.application.guid:unknown}"</management.metrics.tags.application.guid>
-
                                     <!-- Wavefront Tracing -->
                                     <wavefront.application.name>"${spring.cloud.dataflow.stream.name:unknown}</wavefront.application.name>
                                     <wavefront.application.service>${spring.cloud.dataflow.stream.app.label:unknown}-${spring.cloud.dataflow.stream.app.type:unknown}"</wavefront.application.service>
-
+                                    <!-- Zipkin Tracing -->
+                                    <management.tracing.enabled>false</management.tracing.enabled>
+                                    <management.tracing.sampling.probability>1.0</management.tracing.sampling.probability>
                                 </properties>
                                 <metadata>
                                     <mavenPluginVersion>${spring-cloud-dataflow-apps-metadata-plugin.version}</mavenPluginVersion>
@@ -214,7 +215,7 @@
                                         </dependency>
                                         <dependency>
                                             <groupId>io.micrometer</groupId>
-                                            <artifactId>micrometer-registry-prometheus</artifactId>
+                                            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
                                         </dependency>
 										<dependency>
 											<groupId>io.micrometer.prometheus</groupId>
@@ -224,6 +225,23 @@
                                         <dependency>
                                             <groupId>io.micrometer</groupId>
                                             <artifactId>micrometer-registry-wavefront</artifactId>
+                                        </dependency>
+                                        <!-- Tracing -->
+                                        <dependency>
+                                            <groupId>io.micrometer</groupId>
+                                            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>io.zipkin.reporter2</groupId>
+                                            <artifactId>zipkin-reporter-brave</artifactId>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>io.zipkin.reporter2</groupId>
+                                            <artifactId>zipkin-sender-urlconnection</artifactId>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>io.micrometer</groupId>
+                                            <artifactId>micrometer-tracing-reporter-wavefront</artifactId>
                                         </dependency>
                                         <dependency>
                                             <groupId>io.pivotal.cfenv</groupId>

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -156,9 +156,11 @@
                                     <!-- Wavefront Tracing -->
                                     <wavefront.application.name>"${spring.cloud.dataflow.stream.name:unknown}</wavefront.application.name>
                                     <wavefront.application.service>${spring.cloud.dataflow.stream.app.label:unknown}-${spring.cloud.dataflow.stream.app.type:unknown}"</wavefront.application.service>
-                                    <!-- Zipkin Tracing -->
+                                    <!-- Disable Tracing and all Tracing exporters -->
                                     <management.tracing.enabled>false</management.tracing.enabled>
                                     <management.tracing.sampling.probability>1.0</management.tracing.sampling.probability>
+                                    <management.zipkin.tracing.enabled>false</management.zipkin.tracing.enabled>
+                                    <management.wavefront.tracing.enabled>false</management.wavefront.tracing.enabled>
                                 </properties>
                                 <metadata>
                                     <mavenPluginVersion>${spring-cloud-dataflow-apps-metadata-plugin.version}</mavenPluginVersion>

--- a/full-build-no-test.sh
+++ b/full-build-no-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+SCDIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+SCDIR=$(realpath $SCDIR)
+$SCDIR/build-core.sh "-T 0.5C install -Psnapshot -P-integration -DskipTests"
+$SCDIR/build-folder.sh ./applications/processor,./applications/sink,./applications/source,./applications/stream-applications-integration-tests,stream-applications-release-train "-T 0.5C install -Psnapshot -P-integration -DskipTests"


### PR DESCRIPTION
This PR adds the required dependencies for Micrometer Tracing with the Brave bridge
with the ability to report trace to Zipkin or Wavefront. 

Also the following unrelated commits are piggybacking:
- covenience script to do a full build w/o tests
- update to Prometheus Rsocket 2.0.0-M1

> [!IMPORTANT]
> During merge please keep the commits separate as they are unrelated