### PR TITLE
Fix dependency mgmt in generated apps pom.xml

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -159,19 +159,14 @@
                                     <!-- Disable Tracing and all Tracing exporters -->
                                     <management.tracing.enabled>false</management.tracing.enabled>
                                     <management.tracing.sampling.probability>1.0</management.tracing.sampling.probability>
-                                    <management.zipkin.tracing.enabled>false</management.zipkin.tracing.enabled>
-                                    <management.wavefront.tracing.enabled>false</management.wavefront.tracing.enabled>
+                                    <management.zipkin.tracing.export.enabled>false</management.zipkin.tracing.export.enabled>
+                                    <management.wavefront.tracing.export.enabled>false</management.wavefront.tracing.export.enabled>
                                 </properties>
                                 <metadata>
                                     <mavenPluginVersion>${spring-cloud-dataflow-apps-metadata-plugin.version}</mavenPluginVersion>
                                 </metadata>
                                 <maven>
                                     <dependencyManagement>
-                                        <dependency>
-                                            <groupId>io.micrometer.prometheus</groupId>
-                                            <artifactId>prometheus-rsocket-spring</artifactId>
-                                            <version>${prometheus-rsocket.version}</version>
-                                        </dependency>
                                         <!-- Temporarily override SC-Fn dependency by giving it the highest precedence since 2020.0.5 release of spring-cloud will not take place until December -->
                                         <dependency>
                                             <groupId>org.springframework.cloud</groupId>
@@ -225,6 +220,7 @@
                                         <dependency>
                                             <groupId>io.micrometer.prometheus</groupId>
                                             <artifactId>prometheus-rsocket-spring</artifactId>
+                                            <version>${prometheus-rsocket.version}</version>
                                         </dependency>
                                         <dependency>
                                             <groupId>io.micrometer</groupId>


### PR DESCRIPTION
The previous commit for adding Tracing attempted to use dependency management for the `prometheus-rsocket-spring` lib in the generated applications pom.xml. However, the app generator plugin assumes the dep mgmt is for a POM and adds tags for this which fails at runtime.
This commit removes the dep. mgmt. for `prometheus-rsocket-spring` and instead specifies the version on the dependency.

Also, the tracing property for Wavefront and Zipkin are updated.