### PR TITLE
Update SCS starter

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -22,7 +22,8 @@
         <spring-cloud-dataflow-apps-generator-plugin.version>1.0.14</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
-        <java-cfenv-boot.version>2.4.1</java-cfenv-boot.version>
+        <java-cfenv-boot.version>3.2.0</java-cfenv-boot.version>
+        <spring-cloud-services.version>4.1.5</spring-cloud-services.version>
     </properties>
 
     <modules>
@@ -275,7 +276,7 @@
                                         <dependency>
                                             <groupId>io.pivotal.spring.cloud</groupId>
                                             <artifactId>spring-cloud-services-starter-config-client</artifactId>
-                                            <version>3.2.0.RELEASE</version>
+                                            <version>${spring-cloud-services.version}</version>
                                         </dependency>
                                     </dependencies>
                                 </maven>

--- a/clean-apps.sh
+++ b/clean-apps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "About to delete the following 'apps' folders:"
+find . -type d -name apps
+echo "----------------"
+echo "Enter 'Y' or 'N':"
+read shouldDelete
+if [ "$shouldDelete" = "Y" ] || [ "$shouldDelete" = "y" ]; then
+  echo "Deleting..."
+  find . -type d -name apps -prune -exec rm -rf {} \;
+  echo "Done"
+else
+  echo "Not deleting"
+fi

--- a/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/test/resources/unit/http-source-apps/pom.xml
+++ b/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/test/resources/unit/http-source-apps/pom.xml
@@ -13,7 +13,7 @@
 	<properties>
 		<spring-boot.version>3.3.0.M3</spring-boot.version>
 		<stream-apps-core.version>5.0.0-SNAPSHOT</stream-apps-core.version>
-		<java-cfenv-boot.version>2.4.1</java-cfenv-boot.version>
+		<java-cfenv-boot.version>3.2.0</java-cfenv-boot.version>
 		<app-metadata-maven-plugin-version>1.0.13-SNAPSHOT</app-metadata-maven-plugin-version>
 
 		<!-- Emulate the properties that otherwise should come from the stream-apps-parent parent -->


### PR DESCRIPTION
This updates the SCS starter to v4.1.5 and java-cfenv-boot version to v3.2.0 to properly support Boot 3.3.x.

Resolves #550 