### PR TITLE
Update SCS and java-cfenv versions (2022.0.x)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -135,23 +135,9 @@ jobs:
       - name: 'Built'
         shell: bash
         run: echo "::info ::Built"
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'fs'
-          ignore-unfixed: true
-          format: 'table'
-          severity: 'CRITICAL,HIGH'
-      - name: 'Scanned'
-        shell: bash
-        run: echo "::info ::Scanned"
   done:
     runs-on: ubuntu-latest
-    needs: [ scan, build ]
+    needs: [ build ]
     steps:
       - name: 'Done'
         shell: bash

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -59,6 +59,8 @@
         <curator.version>5.5.0</curator.version>
         <mavenThreads>1</mavenThreads>
 
+		<!-- NO CHANGES - JUST TESTING -->
+
 		<!--suppress UnresolvedMavenProperty -->
 		<buildName>${env.BUILD_NAME}</buildName>
 		<!--suppress UnresolvedMavenProperty -->

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -59,7 +59,7 @@
         <curator.version>5.5.0</curator.version>
         <mavenThreads>1</mavenThreads>
 
-		<!-- NO CHANGES - JUST TESTING -->
+		<!-- NO CHANGES - JUST TESTING (take 2) -->
 
 		<!--suppress UnresolvedMavenProperty -->
 		<buildName>${env.BUILD_NAME}</buildName>

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -59,7 +59,7 @@
         <curator.version>5.5.0</curator.version>
         <mavenThreads>1</mavenThreads>
 
-		<!-- NO CHANGES - JUST TESTING (take 2) -->
+		<!-- NO CHANGES - JUST TESTING (take 3) -->
 
 		<!--suppress UnresolvedMavenProperty -->
 		<buildName>${env.BUILD_NAME}</buildName>


### PR DESCRIPTION
This updates the SCS starter to v4.0.5 and java-cfenv-boot version to v3.2.0 to properly support Boot 3.1.x.

SA 2022.0.x (4.0.x) is on SB 3.1.x therefore...
* As per the SCS compat matrix ([here](https://github.com/pivotal-cf/spring-cloud-services-starters?tab=readme-ov-file#compatibility-matrix)) SCS starter should be the 4.0.x line (latest is 4.0.5)
* As per the java-cf-env compat matrix ([here](https://github.com/pivotal-cf/java-cfenv?tab=readme-ov-file#compatibility)) java-cf-env should be the 3.x (latest is 3.2.0)



See #550