### PR TITLE
Update various dependencies patch versions (2022.0.x)

### DIFF
--- a/applications/sink/redis-sink/src/test/java/org/springframework/cloud/stream/app/sink/redis/RedisSinkTests.java
+++ b/applications/sink/redis-sink/src/test/java/org/springframework/cloud/stream/app/sink/redis/RedisSinkTests.java
@@ -52,6 +52,7 @@ public class RedisSinkTests implements RedisTestContainerSupport {
 						.getCompleteConfiguration(RedisSinkTestApplication.class))
 				.web(WebApplicationType.NONE)
 				.run("--spring.cloud.function.definition=redisConsumer",
+						"--spring.cloud.stream.bindings.redisConsumer-in-0.consumer.use-native-decoding=true",
 						"--spring.data.redis.url=" + RedisTestContainerSupport.getUri(),
 						"--redis.consumer.key=foo")) {
 

--- a/applications/sink/s3-sink/README.adoc
+++ b/applications/sink/s3-sink/README.adoc
@@ -44,6 +44,7 @@ $$static$$:: $$<documentation missing>$$ *($$String$$, default: `$$<none>$$`)*
 $$accelerate-mode-enabled$$:: $$Option to enable using the accelerate endpoint when accessing S3. Accelerate endpoints allow faster transfer of objects by using Amazon CloudFront's globally distributed edge locations.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$checksum-validation-enabled$$:: $$Option to disable doing a validation of the checksum of an object stored in S3.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$chunked-encoding-enabled$$:: $$Option to enable using chunked encoding when signing the request payload for {@link software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link software.amazon.awssdk.services.s3.model.UploadPartRequest}.$$ *($$Boolean$$, default: `$$<none>$$`)*
+$$cross-region-enabled$$:: $$Enables cross-region bucket access.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$endpoint$$:: $$Overrides the default endpoint.$$ *($$URI$$, default: `$$<none>$$`)*
 $$path-style-access-enabled$$:: $$Option to enable using path style access for accessing S3 objects instead of DNS style access. DNS style access is preferred as it will result in better load balancing when accessing S3.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$region$$:: $$Overrides the default region.$$ *($$String$$, default: `$$<none>$$`)*

--- a/applications/source/jms-source/README.adoc
+++ b/applications/source/jms-source/README.adoc
@@ -30,7 +30,7 @@ $$pub-sub-domain$$:: $$Whether the default destination type is topic.$$ *($$Bool
 
 $$acknowledge-mode$$:: $$Acknowledge mode of the container. By default, the listener is transacted with automatic acknowledgment.$$ *($$AcknowledgeMode$$, default: `$$<none>$$`, possible values: `AUTO`,`CLIENT`,`DUPS_OK`)*
 $$auto-startup$$:: $$Start the container automatically on startup.$$ *($$Boolean$$, default: `$$true$$`)*
-$$concurrency$$:: $$Minimum number of concurrent consumers.$$ *($$Integer$$, default: `$$<none>$$`)*
+$$concurrency$$:: $$Minimum number of concurrent consumers. When max-concurrency is not specified the minimum will also be used as the maximum.$$ *($$Integer$$, default: `$$<none>$$`)*
 $$max-concurrency$$:: $$Maximum number of concurrent consumers.$$ *($$Integer$$, default: `$$<none>$$`)*
 $$receive-timeout$$:: $$Timeout to use for receive calls. Use -1 for a no-wait receive or 0 for no timeout at all. The latter is only feasible if not running within a transaction manager and is generally discouraged since it prevents clean shutdown.$$ *($$Duration$$, default: `$$1s$$`)*
 //end::configuration-properties[]

--- a/applications/source/s3-source/README.adoc
+++ b/applications/source/s3-source/README.adoc
@@ -126,6 +126,7 @@ $$static$$:: $$<documentation missing>$$ *($$String$$, default: `$$<none>$$`)*
 $$accelerate-mode-enabled$$:: $$Option to enable using the accelerate endpoint when accessing S3. Accelerate endpoints allow faster transfer of objects by using Amazon CloudFront's globally distributed edge locations.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$checksum-validation-enabled$$:: $$Option to disable doing a validation of the checksum of an object stored in S3.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$chunked-encoding-enabled$$:: $$Option to enable using chunked encoding when signing the request payload for {@link software.amazon.awssdk.services.s3.model.PutObjectRequest} and {@link software.amazon.awssdk.services.s3.model.UploadPartRequest}.$$ *($$Boolean$$, default: `$$<none>$$`)*
+$$cross-region-enabled$$:: $$Enables cross-region bucket access.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$endpoint$$:: $$Overrides the default endpoint.$$ *($$URI$$, default: `$$<none>$$`)*
 $$path-style-access-enabled$$:: $$Option to enable using path style access for accessing S3 objects instead of DNS style access. DNS style access is preferred as it will result in better load balancing when accessing S3.$$ *($$Boolean$$, default: `$$<none>$$`)*
 $$region$$:: $$Overrides the default region.$$ *($$String$$, default: `$$<none>$$`)*

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -23,7 +23,8 @@
         <spring-cloud-dataflow-apps-generator-plugin.version>1.0.14</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
-        <java-cfenv-boot.version>2.4.0</java-cfenv-boot.version>
+        <java-cfenv-boot.version>3.2.0</java-cfenv-boot.version>
+        <spring-cloud-services.version>4.0.5</spring-cloud-services.version>
     </properties>
 
     <modules>
@@ -262,7 +263,7 @@
                                         <dependency>
                                             <groupId>io.pivotal.spring.cloud</groupId>
                                             <artifactId>spring-cloud-services-starter-config-client</artifactId>
-                                            <version>3.2.0.RELEASE</version>
+                                            <version>${spring-cloud-services.version}</version>
                                         </dependency>
                                     </dependencies>
                                 </maven>

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -20,9 +20,9 @@
         <java-functions.version>4.0.1-SNAPSHOT</java-functions.version>
         <apps.base-image>springcloud/baseimage:1.0.4</apps.base-image>
 		<prometheus-rsocket.version>1.5.2</prometheus-rsocket.version>
-        <spring-cloud-dataflow-apps-generator-plugin.version>1.0.10</spring-cloud-dataflow-apps-generator-plugin.version>
-        <spring-cloud-dataflow-apps-docs-plugin.version>1.0.10</spring-cloud-dataflow-apps-docs-plugin.version>
-        <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.10</spring-cloud-dataflow-apps-metadata-plugin.version>
+        <spring-cloud-dataflow-apps-generator-plugin.version>1.0.14</spring-cloud-dataflow-apps-generator-plugin.version>
+        <spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
+        <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
         <java-cfenv-boot.version>2.4.0</java-cfenv-boot.version>
     </properties>
 

--- a/clean-apps.sh
+++ b/clean-apps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "About to delete the following 'apps' folders:"
+find . -type d -name apps
+echo "----------------"
+echo "Enter 'Y' or 'N':"
+read shouldDelete
+if [ "$shouldDelete" = "Y" ] || [ "$shouldDelete" = "y" ]; then
+  echo "Deleting..."
+  find . -type d -name apps -prune -exec rm -rf {} \;
+  echo "Done"
+else
+  echo "Not deleting"
+fi

--- a/functions/common/function-test-support/pom.xml
+++ b/functions/common/function-test-support/pom.xml
@@ -14,7 +14,7 @@
     <description>file consumer</description>
 
     <properties>
-        <sshd-sftp.version>2.7.0</sshd-sftp.version>
+        <sshd-sftp.version>2.9.3</sshd-sftp.version>
         <apache-ftpserver.version>1.2.0</apache-ftpserver.version>
     </properties>
 

--- a/functions/consumer/s3-consumer/src/test/java/org/springframework/cloud/fn/consumer/s3/AbstractAwsS3ConsumerMockTests.java
+++ b/functions/consumer/s3-consumer/src/test/java/org/springframework/cloud/fn/consumer/s3/AbstractAwsS3ConsumerMockTests.java
@@ -36,6 +36,7 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.Message;
@@ -43,16 +44,14 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.Mockito.spy;
 
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = {
-				"spring.cloud.aws.credentials.accessKey=" + AbstractAwsS3ConsumerMockTests.AWS_ACCESS_KEY,
+		properties = { "spring.cloud.aws.credentials.accessKey=" + AbstractAwsS3ConsumerMockTests.AWS_ACCESS_KEY,
 				"spring.cloud.aws.credentials.secretKey=" + AbstractAwsS3ConsumerMockTests.AWS_SECRET_KEY,
 				"spring.cloud.aws.region.static=" + AbstractAwsS3ConsumerMockTests.AWS_REGION,
 				"spring.cloud.aws.s3.endpoint=s3://foo",
-				"s3.consumer.bucket=" + AbstractAwsS3ConsumerMockTests.S3_BUCKET})
+				"s3.consumer.bucket=" + AbstractAwsS3ConsumerMockTests.S3_BUCKET })
 public abstract class AbstractAwsS3ConsumerMockTests {
 
 	protected static final String AWS_ACCESS_KEY = "test.accessKey";
@@ -66,7 +65,7 @@ public abstract class AbstractAwsS3ConsumerMockTests {
 	@TempDir
 	protected static Path temporaryRemoteFolder;
 
-	@Autowired
+	@MockBean
 	private S3AsyncClient amazonS3;
 
 	@Autowired
@@ -80,10 +79,7 @@ public abstract class AbstractAwsS3ConsumerMockTests {
 
 	@BeforeEach
 	public void setupTest() {
-		S3AsyncClient amazonS3 = spy(this.amazonS3);
-
-		willReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build()))
-				.given(amazonS3)
+		willReturn(CompletableFuture.completedFuture(PutObjectResponse.builder().build())).given(amazonS3)
 				.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class));
 
 		new DirectFieldAccessor(this.s3TransferManager).setPropertyValue("s3AsyncClient", amazonS3);
@@ -100,7 +96,6 @@ public abstract class AbstractAwsS3ConsumerMockTests {
 		@Bean
 		public TransferListener transferListener() {
 			return new TransferListener() {
-
 
 				@Override
 				public void transferComplete(Context.TransferComplete context) {

--- a/functions/consumer/s3-consumer/src/test/java/org/springframework/cloud/fn/consumer/s3/AmazonS3UploadInputStreamTests.java
+++ b/functions/consumer/s3-consumer/src/test/java/org/springframework/cloud/fn/consumer/s3/AmazonS3UploadInputStreamTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.fn.consumer.s3;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -42,22 +43,18 @@ public class AmazonS3UploadInputStreamTests extends AbstractAwsS3ConsumerMockTes
 
 	@Test
 	public void test() throws Exception {
-		S3AsyncClient amazonS3Client =
-				TestUtils.getPropertyValue(this.s3TransferManager, "s3AsyncClient", S3AsyncClient.class);
+		S3AsyncClient amazonS3Client = TestUtils.getPropertyValue(this.s3TransferManager, "s3AsyncClient",
+				S3AsyncClient.class);
 
 		InputStream payload = new StringInputStream("a");
-		Message<?> message = MessageBuilder.withPayload(payload)
-				.setHeader("key", "myInputStream")
-				.build();
+		Message<?> message = MessageBuilder.withPayload(payload).setHeader("key", "myInputStream").build();
 
 		this.s3Consumer.accept(message);
 
-		ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor =
-				ArgumentCaptor.forClass(PutObjectRequest.class);
-		ArgumentCaptor<AsyncRequestBody> asyncRequestBodyArgumentCaptor =
-				ArgumentCaptor.forClass(AsyncRequestBody.class);
-		verify(amazonS3Client, atLeastOnce())
-				.putObject(putObjectRequestArgumentCaptor.capture(), asyncRequestBodyArgumentCaptor.capture());
+		ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor.captor();
+		ArgumentCaptor<AsyncRequestBody> asyncRequestBodyArgumentCaptor = ArgumentCaptor.captor();
+		verify(amazonS3Client, atLeastOnce()).putObject(putObjectRequestArgumentCaptor.capture(),
+				asyncRequestBodyArgumentCaptor.capture());
 
 		PutObjectRequest putObjectRequest = putObjectRequestArgumentCaptor.getValue();
 		assertThat(putObjectRequest.bucket()).isEqualTo(S3_BUCKET);
@@ -67,9 +64,8 @@ public class AmazonS3UploadInputStreamTests extends AbstractAwsS3ConsumerMockTes
 		assertThat(putObjectRequest.contentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
 		assertThat(putObjectRequest.contentDisposition()).isEqualTo("test.json");
 
-
 		AsyncRequestBody asyncRequestBody = asyncRequestBodyArgumentCaptor.getValue();
-		StepVerifier.create(asyncRequestBody.map(buffer -> new String(buffer.array())))
+		StepVerifier.create(asyncRequestBody.map((buffer) -> StandardCharsets.UTF_8.decode(buffer).toString()))
 				.expectNext("a")
 				.expectComplete()
 				.verify();

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -36,33 +36,29 @@
         <disable.nohttp.checks>true</disable.nohttp.checks>
         <spring-javaformat-checkstyle.version>0.0.35</spring-javaformat-checkstyle.version>
 
-        <spring-boot.version>3.1.8</spring-boot.version>
-        <spring.version>6.0.16</spring.version>
-
-        <spring-kafka.version>3.0.13</spring-kafka.version>
-        <spring-rabbit.version>3.0.10</spring-rabbit.version>
-        <!--        <spring-integration.version>6.1.0</spring-integration.version>-->
-
-        <spring-cloud.version>2022.0.4</spring-cloud.version>
+        <spring-boot.version>3.1.12</spring-boot.version>
+        <spring.version>6.0.21</spring.version>
+        <spring-kafka.version>3.0.17</spring-kafka.version>
+        <spring-rabbit.version>3.0.14</spring-rabbit.version>
+        <spring-cloud.version>2022.0.5</spring-cloud.version>
         <spring-cloud-starters.version>4.0.5</spring-cloud-starters.version>
         <spring-cloud-function.version>4.0.6</spring-cloud-function.version>
         <spring-cloud-stream-dependencies.version>4.0.5</spring-cloud-stream-dependencies.version>
-
-        <testcontainers.version>1.18.3</testcontainers.version>
-        <mockserver.version>5.13.2</mockserver.version>
-
         <groovy.version>4.0.14</groovy.version>
         <apache-ivy.version>2.5.2</apache-ivy.version>
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
-        <spring-cloud-aws.version>3.0.2</spring-cloud-aws.version>
-        <spring-integration-aws.version>3.0.2</spring-integration-aws.version>
+        <spring-cloud-aws.version>3.0.5</spring-cloud-aws.version>
+        <spring-integration-aws.version>3.0.8</spring-integration-aws.version>
         <curator.version>5.5.0</curator.version>
-        <mavenThreads>1</mavenThreads>
+        <testcontainers.version>1.18.3</testcontainers.version>
+        <mockito.version>5.14.2</mockito.version>
+		<mockserver.version>5.13.2</mockserver.version>
 
-		<!--suppress UnresolvedMavenProperty -->
-		<buildName>${env.BUILD_NAME}</buildName>
-		<!--suppress UnresolvedMavenProperty -->
-		<buildNumber>${env.BUILD_NUMBER}</buildNumber>
+        <mavenThreads>1</mavenThreads>
+        <!--suppress UnresolvedMavenProperty -->
+        <buildName>${env.BUILD_NAME}</buildName>
+        <!--suppress UnresolvedMavenProperty -->
+        <buildNumber>${env.BUILD_NUMBER}</buildNumber>
 	</properties>
 
     <url>https://spring.io/projects/spring-cloud-stream-applications</url>
@@ -81,6 +77,13 @@
 
     <dependencyManagement>
         <dependencies>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-bom</artifactId>
+				<version>${mockito.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
> [!NOTE]
> This encompasses several related, yet explicitly separated w/ their own commit messages, commits. Please, whoever merges this do a REBASE rather than SQUASH. Please and ty.

This PR updates various dependencies to the latest patch versions as follows:

- spring-boot to 3.1.12
- spring-framework to 6.0.21
- spring-integration-aws to 3.0.2
- spring-cloud to 2022.0.5
- spring-cloud-aws to 3.0.2
- spring-kafka to 6.0.21
- spring-amqp to 3.0.14
- org.apache.sshd:sshd-sftp to 2.9.3

Quite a few things had to happen along the way to make the above work. See commit messages for details