### PR TITLE
Set spring.cloud.bootstrap.enabled=true by default

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -143,6 +143,7 @@
                                 </containerImage>
                                 <properties>
                                     <!-- Disable all meter repositories by default.  -->
+                                    <spring.cloud.bootstrap.enabled>true</spring.cloud.bootstrap.enabled>
                                     <management.wavefront.metrics.export.enabled>false</management.wavefront.metrics.export.enabled>
                                     <management.influx.metrics.export.enabled>false</management.influx.metrics.export.enabled>
                                     <management.datadog.metrics.export.enabled>false</management.datadog.metrics.export.enabled>


### PR DESCRIPTION
Set spring.cloud.bootstrap.enabled=true by default which allows the containers for the ITs to properly start.