### PR TITLE
Update Spring Boot to 3.3.6 and bump other dependencies

### DIFF
--- a/.github/actions/install-trivy/action.yml
+++ b/.github/actions/install-trivy/action.yml
@@ -7,4 +7,4 @@ runs:
     - name: 'Install Trivy'
       shell: bash
       run: |
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.50.1
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.57.1

--- a/applications/processor/header-filter-processor/src/test/java/org/springframework/cloud/stream/app/processor/header/filter/HeaderFilterProcessorTests.java
+++ b/applications/processor/header-filter-processor/src/test/java/org/springframework/cloud/stream/app/processor/header/filter/HeaderFilterProcessorTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.app.processor.header.filter;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.WebApplicationType;
@@ -67,7 +66,6 @@ public class HeaderFilterProcessorTests {
 		}
 	}
 
-	@NotNull
 	private static Set<String> getNonReadOnlyHeaders(Message<byte[]> message) {
 		var headers = new HashSet<>(message.getHeaders().keySet());
 		var accessor = new IntegrationMessageHeaderAccessor(message);

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -17,13 +17,13 @@
 
     <properties>
         <stream-apps-core.version>5.0.1-SNAPSHOT</stream-apps-core.version>
-        <java-functions.version>5.0.1-SNAPSHOT</java-functions.version>
-        <prometheus-rsocket.version>2.0.0-M1</prometheus-rsocket.version>
+        <java-functions.version>5.0.1</java-functions.version>
+        <prometheus-rsocket.version>2.0.0-M2</prometheus-rsocket.version>
         <spring-cloud-dataflow-apps-generator-plugin.version>1.0.14</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
         <java-cfenv-boot.version>3.2.0</java-cfenv-boot.version>
-        <spring-cloud-services.version>4.1.5</spring-cloud-services.version>
+        <spring-cloud-services.version>4.1.6</spring-cloud-services.version>
     </properties>
 
     <modules>

--- a/scan-folders.sh
+++ b/scan-folders.sh
@@ -4,19 +4,22 @@ SCDIR=$(realpath $SCDIR)
 if [ -f $SCDIR/runs.sarif ]; then
   rm $SCDIR/runs.sarif
 fi
-export TRIVY_UPLOAD=true
+TRIVY_UPLOAD=true
 while [ "$1" != "" ]; do
   if [ "$1" == "table" ]; then
-    export TRIVY_UPLOAD=false
+    TRIVY_UPLOAD=false
   fi
   shift
 done
+export TRIVY_UPLOAD
 REAL_PATH=$(realpath $PWD)
 echo "Scanning in $REAL_PATH"
 find . -type d -name target -exec bash "$SCDIR/scan-jars.sh" '{}' \;
-echo "{\"version\": \"2.1.0\", \"\$schema\": \"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json\", \"runs\": [" > "$SCDIR/scan.sarif"
-if [ -f "$SCDIR/runs.sarif" ]; then
-  cat "$SCDIR/runs.sarif" >> "$SCDIR/scan.sarif"
+if [ "$TRIVY_UPLOAD" = "true" ]; then
+  echo "{\"version\": \"2.1.0\", \"\$schema\": \"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json\", \"runs\": [" > "$SCDIR/scan.sarif"
+  if [ -f "$SCDIR/runs.sarif" ]; then
+    cat "$SCDIR/runs.sarif" >> "$SCDIR/scan.sarif"
+  fi
+  echo "]}" >> "$SCDIR/scan.sarif"
+  echo "Created $SCDIR/scan.sarif"
 fi
-echo "]}" >> "$SCDIR/scan.sarif"
-echo "Created $SCDIR/scan.sarif"

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -32,26 +32,24 @@
         <checkstyle.nohttp.file>${checkstyle.location}/nohttp-checkstyle.xml</checkstyle.nohttp.file>
         <checkstyle.additional.suppressions.file>${checkstyle.location}/checkstyle-suppressions.xml
         </checkstyle.additional.suppressions.file>
-        <nohttp-checkstyle.version>0.0.10</nohttp-checkstyle.version>
+        <nohttp-checkstyle.version>0.0.11</nohttp-checkstyle.version>
         <disable.nohttp.checks>true</disable.nohttp.checks>
-        <spring-javaformat-checkstyle.version>0.0.35</spring-javaformat-checkstyle.version>
-        <spring-boot.version>3.3.1</spring-boot.version>
-        <spring.version>6.1.10</spring.version>
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
-        <spring-cloud-starters.version>4.1.2</spring-cloud-starters.version>
-        <spring-cloud-function.version>4.1.2</spring-cloud-function.version>
-        <spring-cloud-stream-dependencies.version>4.1.2</spring-cloud-stream-dependencies.version>
+        <spring-javaformat-checkstyle.version>0.0.43</spring-javaformat-checkstyle.version>
+        <spring-boot.version>3.3.6</spring-boot.version>
+        <spring.version>6.1.15</spring.version>
+        <spring-cloud.version>2023.0.4</spring-cloud.version>
+        <spring-cloud-starters.version>4.1.5</spring-cloud-starters.version>
+        <spring-cloud-function.version>4.1.4</spring-cloud-function.version>
+        <spring-cloud-stream-dependencies.version>4.1.4</spring-cloud-stream-dependencies.version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <mockserver.version>5.15.0</mockserver.version>
-        <groovy.version>4.0.21</groovy.version>
+        <groovy.version>4.0.24</groovy.version>
         <apache-ivy.version>2.5.2</apache-ivy.version>
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
-        <spring-cloud-aws.version>3.1.1</spring-cloud-aws.version>
-        <spring-integration-aws.version>3.0.7</spring-integration-aws.version>
         <curator.version>5.5.0</curator.version>
         <mavenThreads>1</mavenThreads>
         <commons-compress.version>1.26.2</commons-compress.version>
-        <json-path.version>2.9.0</json-path.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
 		<!--suppress UnresolvedMavenProperty -->
 		<buildName>${env.BUILD_NAME}</buildName>
 		<!--suppress UnresolvedMavenProperty -->
@@ -75,14 +73,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.jayway.jsonpath</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${json-path.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -134,13 +132,6 @@
                 <groupId>org.apache.ivy</groupId>
                 <artifactId>ivy</artifactId>
                 <version>${apache-ivy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.awspring.cloud</groupId>
-                <artifactId>spring-cloud-aws-dependencies</artifactId>
-                <version>${spring-cloud-aws.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Updates Spring Functions Catalog to 5.0.1
Updates Spring Boot to 3.3.6
Updates RabbitMQ Http Client to 5.2.0
Updates NoHttp Checkstyle to 0.0.11
Updates Spring Java Format Checkstyle to 0.0.43
Updates Spring Framework to 6.1.15
Updates Spring Cloud Release Train to 2023.0.4
Updates Spring Cloud Starters to 4.1.5
Updates Spring Cloud Function to 4.1.4
Updates Spring Cloud Stream to 4.1.4
Updates Groovy to 4.0.24
Removes spring-integration-aws.version property now manage in Spring Functions Catalog Removes json-path.version as it is managed in Spring Boot dependencies.
Removes Jetbrains `@NotNull` from a Test class.

See #584