### PR TITLE
Update Spring Boot to 3.3.6

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -18,12 +18,12 @@
     <properties>
         <stream-apps-core.version>5.0.1-SNAPSHOT</stream-apps-core.version>
         <java-functions.version>5.0.1-SNAPSHOT</java-functions.version>
-        <prometheus-rsocket.version>2.0.0-M1</prometheus-rsocket.version>
+        <prometheus-rsocket.version>2.0.0-M2</prometheus-rsocket.version>
         <spring-cloud-dataflow-apps-generator-plugin.version>1.0.14</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
         <java-cfenv-boot.version>3.2.0</java-cfenv-boot.version>
-        <spring-cloud-services.version>4.1.5</spring-cloud-services.version>
+        <spring-cloud-services.version>4.1.6</spring-cloud-services.version>
     </properties>
 
     <modules>

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -35,19 +35,19 @@
         <nohttp-checkstyle.version>0.0.10</nohttp-checkstyle.version>
         <disable.nohttp.checks>true</disable.nohttp.checks>
         <spring-javaformat-checkstyle.version>0.0.35</spring-javaformat-checkstyle.version>
-        <spring-boot.version>3.3.1</spring-boot.version>
-        <spring.version>6.1.10</spring.version>
-        <spring-cloud.version>2023.0.2</spring-cloud.version>
-        <spring-cloud-starters.version>4.1.2</spring-cloud-starters.version>
-        <spring-cloud-function.version>4.1.2</spring-cloud-function.version>
-        <spring-cloud-stream-dependencies.version>4.1.2</spring-cloud-stream-dependencies.version>
+        <spring-boot.version>3.3.6</spring-boot.version>
+        <spring.version>6.1.15</spring.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <spring-cloud-starters.version>4.1.4</spring-cloud-starters.version>
+        <spring-cloud-function.version>4.1.3</spring-cloud-function.version>
+        <spring-cloud-stream-dependencies.version>4.1.3</spring-cloud-stream-dependencies.version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <mockserver.version>5.15.0</mockserver.version>
         <groovy.version>4.0.21</groovy.version>
         <apache-ivy.version>2.5.2</apache-ivy.version>
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
-        <spring-cloud-aws.version>3.1.1</spring-cloud-aws.version>
-        <spring-integration-aws.version>3.0.7</spring-integration-aws.version>
+		<spring-cloud-aws.version>3.1.1</spring-cloud-aws.version>
+		<spring-integration-aws.version>3.0.8</spring-integration-aws.version>
         <curator.version>5.5.0</curator.version>
         <mavenThreads>1</mavenThreads>
         <commons-compress.version>1.26.2</commons-compress.version>


### PR DESCRIPTION
This updates Spring Boot to version 3.3.6 and other various dependencies to their latest available patch version.

See #584