### PR TITLE
Use latest release of Prometheus Rsocket Proxy 1.5.3

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <stream-apps-core.version>5.0.1-SNAPSHOT</stream-apps-core.version>
         <java-functions.version>5.0.1</java-functions.version>
-        <prometheus-rsocket.version>2.0.0-M3</prometheus-rsocket.version>
+        <prometheus-rsocket.version>1.5.3</prometheus-rsocket.version>
         <spring-cloud-dataflow-apps-generator-plugin.version>1.0.14</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>


### PR DESCRIPTION
Updates Prometheus Rsocket Proxy to 1.5.3