### PR TITLE
Use new Prometheus RSocket client

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <stream-apps-core.version>6.0.0-SNAPSHOT</stream-apps-core.version>
         <java-functions.version>5.1.0-SNAPSHOT</java-functions.version>
-        <prometheus-rsocket.version>1.5.3</prometheus-rsocket.version>
+        <prometheus-rsocket.version>2.0.0-M4</prometheus-rsocket.version>
         <spring-cloud-dataflow-apps-generator-plugin.version>1.1.0-SNAPSHOT</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.1.0-SNAPSHOT</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.1.0-SNAPSHOT</spring-cloud-dataflow-apps-metadata-plugin.version>
@@ -180,7 +180,7 @@
                                         </dependency>
                                         <dependency>
                                             <groupId>io.micrometer</groupId>
-                                            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+                                            <artifactId>micrometer-registry-prometheus</artifactId>
                                         </dependency>
                                         <dependency>
                                             <groupId>io.micrometer.prometheus</groupId>


### PR DESCRIPTION
Replaces the `micrometer.io:micrometer-registry-prometheus-simpleclient` with `micrometer.io:micrometer-registry-prometheus`.

Also updates the Prometheus RSocket version from `1.5.3` to `2.0.0-M4`.