### PR TITLE
Update to Spring Boot 3.3.7

### DIFF
--- a/spring-cloud-dataflow-apps-plugin/pom.xml
+++ b/spring-cloud-dataflow-apps-plugin/pom.xml
@@ -37,8 +37,8 @@
 		<maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
 		<commons.io.version>2.16.1</commons.io.version>
 		<commons-text.version>1.12.0</commons-text.version>
-		<spring-boot.version>3.3.6</spring-boot.version>
-		<spring.version>6.1.15</spring.version>
+		<spring-boot.version>3.3.7</spring-boot.version>
+		<spring.version>6.1.16</spring.version>
 		<spring-cloud.version>2023.0.4</spring-cloud.version>
 	</properties>
   	<modules>

--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -35,8 +35,8 @@
         <nohttp-checkstyle.version>0.0.11</nohttp-checkstyle.version>
         <disable.nohttp.checks>true</disable.nohttp.checks>
         <spring-javaformat-checkstyle.version>0.0.43</spring-javaformat-checkstyle.version>
-        <spring-boot.version>3.3.6</spring-boot.version>
-        <spring.version>6.1.15</spring.version>
+        <spring-boot.version>3.3.7</spring-boot.version>
+        <spring.version>6.1.16</spring.version>
         <spring-cloud.version>2023.0.4</spring-cloud.version>
         <spring-cloud-starters.version>4.1.5</spring-cloud-starters.version>
         <spring-cloud-function.version>4.1.4</spring-cloud-function.version>


### PR DESCRIPTION
This commit updates Spring Boot to 3.3.7 and Spring Framework to 6.1.16
in preparation for the 2024.0.1 release.

Resolves #597