### PR TITLE
Override Spring Cloud Function version

### DIFF
--- a/stream-applications-build/pom.xml
+++ b/stream-applications-build/pom.xml
@@ -36,7 +36,9 @@
         <disable.nohttp.checks>true</disable.nohttp.checks>
         <spring-javaformat-checkstyle.version>0.0.43</spring-javaformat-checkstyle.version>
         <spring-boot.version>3.4.2-SNAPSHOT</spring-boot.version>
-        <spring-cloud.version>2024.0.1-SNAPSHOT</spring-cloud.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <!-- SC bom override to pickup spring-cloud/spring-cloud-function#1224 -->
+        <spring-cloud-function.version>4.2.1-SNAPSHOT</spring-cloud-function.version>
         <!-- =================================================================== -->
         <!-- Required only for release train docs generation in -->
         <!-- /stream-applications-release-train/stream-applications-docs/pom.xml -->
@@ -88,6 +90,13 @@
                 <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-function-dependencies</artifactId>
+                <version>${spring-cloud-function.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
This commit overrides the `spring-cloud-function` version manged by `spring-cloud-dependencies` from `4.2.0` to `4.2.1-SNAPSHOT` in order to pickup spring-cloud/spring-cloud-function#1224 which brings the fix for functions declared as `FactoryBean`.

See #599