### PR TITLE
[Apps Plugin] Fix Spring Boot plugin config

### DIFF
--- a/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojo.java
+++ b/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/main/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojo.java
@@ -306,7 +306,7 @@ public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
 				})
 				.collect(Collectors.toList());
 
-		app.setBootPluginConfiguration(this.application.getBootPluginConfiguration());
+		app.setBootPluginConfiguration(deriveBootPluginConfiguration());
 
 		// ----------------------------------------------------------------------------------------------------------
 		//                                 Project Generator
@@ -323,6 +323,18 @@ public class SpringCloudStreamAppGeneratorMojo extends AbstractMojo {
 		catch (IOException e) {
 			throw new MojoFailureException("Project generation failure", e);
 		}
+	}
+
+	private String deriveBootPluginConfiguration() {
+		String imageInfo = "<image><name>{{app.containerImage.orgName}}/${project.artifactId}:{{app.containerImage.tag}}</name></image>";
+		String bootPluginConfig = this.application.getBootPluginConfiguration();
+		if (!StringUtils.hasText(bootPluginConfig)) {
+			return "<![CDATA[%n%s%n]]>".formatted(imageInfo);
+		}
+		if (bootPluginConfig.contains("<image>") && bootPluginConfig.contains("</image>")) {
+			return bootPluginConfig;
+		}
+		return bootPluginConfig.replace("<![CDATA[", "<![CDATA[%n%s%n".formatted(imageInfo));
 	}
 
 	private boolean isSameArtifact(Dependency dep1, Dependency dep2) {

--- a/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
+++ b/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/main/resources/template/app-pom.xml
@@ -135,21 +135,15 @@
 			{{this}}
 			{{/app-binder.maven.plugins}}
 			<!-- (end) additional plugins -->
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<image>
-						<name>{{app.containerImage.orgName}}/${project.artifactId}:{{app.containerImage.tag}}</name>
-					</image>
-					<!-- extra configuration -->
-					{{#app.bootPluginConfiguration}}
-					{{this}}
-					{{/app.bootPluginConfiguration}}
-					<!-- (end) extra configuration -->
-				</configuration>
-			</plugin>
-
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                {{#app.bootPluginConfiguration}}
+                <configuration>
+                    {{this}}
+                </configuration>
+                {{/app.bootPluginConfiguration}}
+            </plugin>
 
 			{{#app.containerImage.enableMetadata}}
 			<!--

--- a/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/test/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojoTest.java
+++ b/spring-cloud-dataflow-apps-plugin/spring-cloud-dataflow-apps-generator-plugin/src/test/java/org/springframework/cloud/dataflow/app/plugin/SpringCloudStreamAppGeneratorMojoTest.java
@@ -160,7 +160,7 @@ public class SpringCloudStreamAppGeneratorMojoTest {
 		final Plugin plugin = bootPlugin.get();
 		final Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
 		assertThat(configuration).isNotNull();
-		String configurationString = configuration.toString();
+		String configurationString = configuration.getValue();
 		assertThat(configurationString).contains("<requiresUnpack>");
 		assertThat(configurationString).contains("jython-standalone");
 		assertThat(configurationString).contains("</requiresUnpack>");


### PR DESCRIPTION
The recent JIB removal broke the Spring Boot plugin config generation due to a Mustache complication with nested sections. This fixes that by ensuring that the `<image>` configuration is always present regardless of what the user configures.