### PR TITLE
Downgrade to prometheus-rsocket-proxy 1.5.3

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <stream-apps-core.version>5.1.0-SNAPSHOT</stream-apps-core.version>
         <java-functions.version>5.1.0</java-functions.version>
-        <prometheus-rsocket.version>2.0.0-M4</prometheus-rsocket.version>
+        <prometheus-rsocket.version>1.5.3</prometheus-rsocket.version>
         <spring-cloud-dataflow-apps-generator-plugin.version>1.1.0-SNAPSHOT</spring-cloud-dataflow-apps-generator-plugin.version>
         <spring-cloud-dataflow-apps-docs-plugin.version>1.1.0-SNAPSHOT</spring-cloud-dataflow-apps-docs-plugin.version>
         <spring-cloud-dataflow-apps-metadata-plugin.version>1.1.0-SNAPSHOT</spring-cloud-dataflow-apps-metadata-plugin.version>
@@ -180,7 +180,7 @@
                                         </dependency>
                                         <dependency>
                                             <groupId>io.micrometer</groupId>
-                                            <artifactId>micrometer-registry-prometheus</artifactId>
+                                            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
                                         </dependency>
                                         <dependency>
                                             <groupId>io.micrometer.prometheus</groupId>


### PR DESCRIPTION
Since there is not a GA version of prometheus-rsocket-proxy 2.0.0 available, this downgrades back to the simpleclient and version 1.5.3