### PR TITLE
Update Groovy to 3.0.23

### DIFF
--- a/stream-applications-release-train/stream-applications-descriptor/pom.xml
+++ b/stream-applications-release-train/stream-applications-descriptor/pom.xml
@@ -15,12 +15,13 @@
     <packaging>jar</packaging>
     <properties>
         <uniqueVersion>false</uniqueVersion>
+        <groovy.version>3.0.23</groovy.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.17</version>
+            <version>${groovy.version}</version>
             <type>pom</type>
             <scope>compile</scope>
         </dependency>
@@ -52,7 +53,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
-                        <version>3.0.17</version>
+                        <version>${groovy.version}</version>
                         <type>pom</type>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
This updates `org.codehaus.groovy:groovy-all` used by the `stream-applications-release-train` module to `3.0.23` to fix `CVE-2022-4065` from transitive depepdency
`org.testng:testng`.