### PR TITLE
Update apps to use spring-cloud-function 4.2.1

### DIFF
--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -137,6 +137,7 @@
                                     <management.tracing.sampling.probability>1.0</management.tracing.sampling.probability>
                                     <management.zipkin.tracing.export.enabled>false</management.zipkin.tracing.export.enabled>
                                     <management.wavefront.tracing.export.enabled>false</management.wavefront.tracing.export.enabled>
+                                    <spring-cloud-function.version>4.2.1</spring-cloud-function.version>
                                 </properties>
                                 <metadata>
                                     <mavenPluginVersion>${spring-cloud-dataflow-apps-metadata-plugin.version}</mavenPluginVersion>


### PR DESCRIPTION
This updates the generated apps to use the override version of `spring-cloud-function` to `4.2.1`.