### PR TITLE
Fix CVEs for mssql-jdbc and lz4-java

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -6,12 +6,21 @@ CVE-2023-32731
 
 ################################
 # Snakeyaml 1.3.3
-# SCDF usage has been mitigated.
+# Usage has been mitigated.
 ################################
 CVE-2022-1471
 
 ################################
 # Spring Web 5.3.x
-# SCDF not affected.
+# Not affected.
 ################################
 CVE-2016-1000027
+
+################################
+# SqlServer Jdbc Driver
+# Using 12.8.2.jre11 but Trivy
+# does not recognize the jre11
+# suffix and still reports the
+# CVE.
+################################
+CVE-2025-59250

--- a/applications/sink/kafka-sink/pom.xml
+++ b/applications/sink/kafka-sink/pom.xml
@@ -20,6 +20,18 @@
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>spring-kafka-publisher</artifactId>
+			<!-- Exclude lz4-java due to CVE-2025-12183 / CVE-2025-66566 -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.lz4</groupId>
+					<artifactId>lz4-java</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>at.yawk.lz4</groupId>
+			<artifactId>lz4-java</artifactId>
+			<version>${lz4-java.version}</version>
 		</dependency>
 
 		<dependency>
@@ -59,6 +71,18 @@
 								<dependency>
 									<groupId>org.springframework.cloud.fn</groupId>
 									<artifactId>spring-kafka-publisher</artifactId>
+									<!-- Exclude lz4-java due to CVE-2025-12183 / CVE-2025-66566 -->
+									<exclusions>
+										<exclusion>
+											<groupId>org.lz4</groupId>
+											<artifactId>lz4-java</artifactId>
+										</exclusion>
+									</exclusions>
+								</dependency>
+								<dependency>
+									<groupId>at.yawk.lz4</groupId>
+									<artifactId>lz4-java</artifactId>
+									<version>${lz4-java.version}</version>
 								</dependency>
 							</dependencies>
 						</maven>

--- a/applications/source/debezium-source/pom.xml
+++ b/applications/source/debezium-source/pom.xml
@@ -13,6 +13,7 @@
 	<properties>
 		<json-unit.version>1.25.1</json-unit.version>
 		<grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
+		<org-bitbucket-jose4j.version>0.9.6</org-bitbucket-jose4j.version>
 	</properties>
 
 	<artifactId>debezium-source</artifactId>
@@ -24,11 +25,21 @@
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>spring-debezium-supplier</artifactId>
-			<!-- Exclude grpc-netty-shaded due to CVE-2025-55163 -->
 			<exclusions>
+				<!-- Exclude grpc-netty-shaded due to CVE-2025-55163 -->
 				<exclusion>
 					<groupId>io.grpc</groupId>
 					<artifactId>grpc-netty-shaded</artifactId>
+				</exclusion>
+				<!-- Exclude lz4-java due to CVE-2025-12183 / CVE-2025-66566 -->
+				<exclusion>
+					<groupId>org.lz4</groupId>
+					<artifactId>lz4-java</artifactId>
+				</exclusion>
+				<!-- Exclude jose4j due to CVE-2024-29371 -->
+				<exclusion>
+					<groupId>org.bitbucket.b_c</groupId>
+					<artifactId>jose4j</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -36,6 +47,18 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
 			<version>${grpc-netty-shaded.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>at.yawk.lz4</groupId>
+			<artifactId>lz4-java</artifactId>
+			<version>${lz4-java.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.bitbucket.b_c</groupId>
+			<artifactId>jose4j</artifactId>
+			<version>${org-bitbucket-jose4j.version}</version>
+			<scope>runtime</scope>
 		</dependency>
 		<!-- TEST -->
 		<dependency>
@@ -136,11 +159,21 @@
 								<dependency>
 									<groupId>org.springframework.cloud.fn</groupId>
 									<artifactId>spring-debezium-supplier</artifactId>
-									<!-- Exclude grpc-netty-shaded due to CVE-2025-55163 -->
 									<exclusions>
+										<!-- Exclude grpc-netty-shaded due to CVE-2025-55163 -->
 										<exclusion>
 											<groupId>io.grpc</groupId>
 											<artifactId>grpc-netty-shaded</artifactId>
+										</exclusion>
+										<!-- Exclude lz4-java due to CVE-2025-12183 / CVE-2025-66566 -->
+										<exclusion>
+											<groupId>org.lz4</groupId>
+											<artifactId>lz4-java</artifactId>
+										</exclusion>
+										<!-- Exclude jose4j due to CVE-2024-29371 -->
+										<exclusion>
+											<groupId>org.bitbucket.b_c</groupId>
+											<artifactId>jose4j</artifactId>
 										</exclusion>
 									</exclusions>
 								</dependency>
@@ -148,7 +181,20 @@
 									<groupId>io.grpc</groupId>
 									<artifactId>grpc-netty-shaded</artifactId>
 									<version>${grpc-netty-shaded.version}</version>
-								</dependency>								<dependency>
+								</dependency>
+								<dependency>
+									<groupId>at.yawk.lz4</groupId>
+									<artifactId>lz4-java</artifactId>
+									<version>${lz4-java.version}</version>
+									<scope>runtime</scope>
+								</dependency>
+								<dependency>
+									<groupId>org.bitbucket.b_c</groupId>
+									<artifactId>jose4j</artifactId>
+									<version>${org-bitbucket-jose4j.version}</version>
+									<scope>runtime</scope>
+								</dependency>
+								<dependency>
 									<groupId>org.springframework.cloud.stream.app</groupId>
 									<artifactId>stream-applications-composite-function-support</artifactId>
 									<version>${stream-apps-core.version}</version>

--- a/applications/source/kafka-source/pom.xml
+++ b/applications/source/kafka-source/pom.xml
@@ -20,6 +20,17 @@
 		<dependency>
 			<groupId>org.springframework.cloud.fn</groupId>
 			<artifactId>spring-kafka-supplier</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.lz4</groupId>
+					<artifactId>lz4-java</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>at.yawk.lz4</groupId>
+			<artifactId>lz4-java</artifactId>
+			<version>${lz4-java.version}</version>
 		</dependency>
 
 		<dependency>
@@ -53,12 +64,23 @@
 						<version>${project.version}</version>
 						<configClass>AUTOCONFIGURATION</configClass>
 						<functionDefinition>kafkaSupplier</functionDefinition>
-
 						<maven>
 							<dependencies>
+								<!-- Exclude lz4-java due to CVE-2025-12183 / CVE-2025-66566 -->
 								<dependency>
 									<groupId>org.springframework.cloud.fn</groupId>
 									<artifactId>spring-kafka-supplier</artifactId>
+									<exclusions>
+										<exclusion>
+											<groupId>org.lz4</groupId>
+											<artifactId>lz4-java</artifactId>
+										</exclusion>
+									</exclusions>
+								</dependency>
+								<dependency>
+									<groupId>at.yawk.lz4</groupId>
+									<artifactId>lz4-java</artifactId>
+									<version>${lz4-java.version}</version>
 								</dependency>
 							</dependencies>
 						</maven>

--- a/applications/stream-applications-core/pom.xml
+++ b/applications/stream-applications-core/pom.xml
@@ -32,11 +32,8 @@
         <nimbus-oauth2-oidc-sdk.version>9.43.6</nimbus-oauth2-oidc-sdk.version>
         <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
 
-        <!-- Override for CVE-2025-59250 -->
-        <mssql-jdbc.version>12.8.2.jre11</mssql-jdbc.version>
-
-        <!-- Override for CVE-2025-12183 -->
-        <lz4-java.version>1.8.1</lz4-java.version>
+        <!-- Override for CVE-2025-12183 / CVE-2025-66566 -->
+        <lz4-java.version>1.10.3</lz4-java.version>
 
     </properties>
 
@@ -62,16 +59,6 @@
 				<artifactId>mockserver-netty</artifactId>
 				<version>${mockserver.version}</version>
 			</dependency>
-            <dependency>
-                <groupId>com.microsoft.sqlserver</groupId>
-                <artifactId>mssql-jdbc</artifactId>
-                <version>${mssql-jdbc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.lz4</groupId>
-                <artifactId>lz4-java</artifactId>
-                <version>${lz4-java.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -180,16 +167,6 @@
                                             <version>${java-functions.version}</version>
                                             <type>pom</type>
                                             <scope>import</scope>
-                                        </dependency>
-                                        <dependency>
-                                            <groupId>com.microsoft.sqlserver</groupId>
-                                            <artifactId>mssql-jdbc</artifactId>
-                                            <version>${mssql-jdbc.version}</version>
-                                        </dependency>
-                                        <dependency>
-                                            <groupId>org.lz4</groupId>
-                                            <artifactId>lz4-java</artifactId>
-                                            <version>${lz4-java.version}</version>
                                         </dependency>
                                     </dependencyManagement>
                                     <dependencies>
@@ -357,6 +334,18 @@
                                             <dependency>
                                                 <groupId>org.springframework.cloud</groupId>
                                                 <artifactId>spring-cloud-stream-binder-kafka</artifactId>
+                                                <!-- Exclude lz4-java due to CVE-2025-12183 / CVE-2025-66566 -->
+                                                <exclusions>
+                                                    <exclusion>
+                                                        <groupId>org.lz4</groupId>
+                                                        <artifactId>lz4-java</artifactId>
+                                                    </exclusion>
+                                                </exclusions>
+                                            </dependency>
+                                            <dependency>
+                                                <groupId>at.yawk.lz4</groupId>
+                                                <artifactId>lz4-java</artifactId>
+                                                <version>${lz4-java.version}</version>
                                             </dependency>
                                         </dependencies>
                                     </maven>


### PR DESCRIPTION
Moves the previous override of `mssql-jdbc` to where the dependency is used (rather than for all apps) in the `jdbc-source` and `jdbc-sink` apps. Also fixes CVE-2025-8916 by excluding the transitive dependency on `org.bouncycastle:bcpkix-jdk18on:1.78` from `mssql-jdbc` and instead directly brings in Bouncycastle version `1.79`.

Moves the previous override of `lz4-java` to where the dependency is used - in the Kafka binder apps only. Also fixes CVE-2025-66566 by excluding the flawed version of `lz4-java` from `kafka-clients` and instead brings in updated `lz4-java` version `1.10.3`.